### PR TITLE
Update datasets to new metadata API

### DIFF
--- a/llmebench/datasets/ANERcorp.py
+++ b/llmebench/datasets/ANERcorp.py
@@ -5,44 +5,47 @@ class ANERcorpDataset(DatasetBase):
     def __init__(self, **kwargs):
         super(ANERcorpDataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """@InProceedings{10.1007/978-3-540-70939-8_13,
-                    author="Benajiba, Yassine
-                    and Rosso, Paolo
-                    and Bened{\'i}Ruiz, Jos{\'e} Miguel",
-                    editor="Gelbukh, Alexander",
-                    title="ANERsys: An Arabic Named Entity Recognition System Based on Maximum Entropy",
-                    booktitle="Computational Linguistics and Intelligent Text Processing",
-                    year="2007",
-                    publisher="Springer Berlin Heidelberg",
-                    address="Berlin, Heidelberg",
-                    pages="143--153",
-                    abstract="The task of Named Entity Recognition (NER) allows to identify proper names as well as temporal and numeric expressions, in an open-domain text. NER systems proved to be very important for many tasks in Natural Language Processing (NLP) such as Information Retrieval and Question Answering tasks. Unfortunately, the main efforts to build reliable NER systems for the Arabic language have been made in a commercial frame and the approach used as well as the accuracy of the performance are not known. In this paper, we present ANERsys: a NER system built exclusively for Arabic texts based-on n-grams and maximum entropy. Furthermore, we present both the specific Arabic language dependent heuristic and the gazetteers we used to boost our system. We developed our own training and test corpora (ANERcorp) and gazetteers (ANERgazet) to train, evaluate and boost the implemented technique. A major effort was conducted to make sure all the experiments are carried out in the same framework of the CONLL 2002 conference. We carried out several experiments and the preliminary results showed that this approach allows to tackle successfully the problem of NER for the Arabic language.",
-                    isbn="978-3-540-70939-8"
-                }
-                @inproceedings{obeid-etal-2020-camel,
-                    title = "{CAM}e{L} Tools: An Open Source Python Toolkit for {A}rabic Natural Language Processing",
-                    author = "Obeid, Ossama  and
-                      Zalmout, Nasser  and
-                      Khalifa, Salam  and
-                      Taji, Dima  and
-                      Oudah, Mai  and
-                      Alhafni, Bashar  and
-                      Inoue, Go  and
-                      Eryani, Fadhl  and
-                      Erdmann, Alexander  and
-                      Habash, Nizar",
-                    booktitle = "Proceedings of the Twelfth Language Resources and Evaluation Conference",
-                    month = may,
-                    year = "2020",
-                    address = "Marseille, France",
-                    publisher = "European Language Resources Association",
-                    url = "https://aclanthology.org/2020.lrec-1.868",
-                    pages = "7022--7032",
-                    abstract = "We present CAMeL Tools, a collection of open-source tools for Arabic natural language processing in Python. CAMeL Tools currently provides utilities for pre-processing, morphological modeling, Dialect Identification, Named Entity Recognition and Sentiment Analysis. In this paper, we describe the design of CAMeL Tools and the functionalities it provides.",
-                    language = "English",
-                    ISBN = "979-10-95546-34-4",
-                }"""
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@InProceedings{10.1007/978-3-540-70939-8_13,
+                author="Benajiba, Yassine
+                and Rosso, Paolo
+                and Bened{\'i}Ruiz, Jos{\'e} Miguel",
+                editor="Gelbukh, Alexander",
+                title="ANERsys: An Arabic Named Entity Recognition System Based on Maximum Entropy",
+                booktitle="Computational Linguistics and Intelligent Text Processing",
+                year="2007",
+                publisher="Springer Berlin Heidelberg",
+                address="Berlin, Heidelberg",
+                pages="143--153",
+                abstract="The task of Named Entity Recognition (NER) allows to identify proper names as well as temporal and numeric expressions, in an open-domain text. NER systems proved to be very important for many tasks in Natural Language Processing (NLP) such as Information Retrieval and Question Answering tasks. Unfortunately, the main efforts to build reliable NER systems for the Arabic language have been made in a commercial frame and the approach used as well as the accuracy of the performance are not known. In this paper, we present ANERsys: a NER system built exclusively for Arabic texts based-on n-grams and maximum entropy. Furthermore, we present both the specific Arabic language dependent heuristic and the gazetteers we used to boost our system. We developed our own training and test corpora (ANERcorp) and gazetteers (ANERgazet) to train, evaluate and boost the implemented technique. A major effort was conducted to make sure all the experiments are carried out in the same framework of the CONLL 2002 conference. We carried out several experiments and the preliminary results showed that this approach allows to tackle successfully the problem of NER for the Arabic language.",
+                isbn="978-3-540-70939-8"
+            }
+            @inproceedings{obeid-etal-2020-camel,
+                title = "{CAM}e{L} Tools: An Open Source Python Toolkit for {A}rabic Natural Language Processing",
+                author = "Obeid, Ossama  and
+                  Zalmout, Nasser  and
+                  Khalifa, Salam  and
+                  Taji, Dima  and
+                  Oudah, Mai  and
+                  Alhafni, Bashar  and
+                  Inoue, Go  and
+                  Eryani, Fadhl  and
+                  Erdmann, Alexander  and
+                  Habash, Nizar",
+                booktitle = "Proceedings of the Twelfth Language Resources and Evaluation Conference",
+                month = may,
+                year = "2020",
+                address = "Marseille, France",
+                publisher = "European Language Resources Association",
+                url = "https://aclanthology.org/2020.lrec-1.868",
+                pages = "7022--7032",
+                abstract = "We present CAMeL Tools, a collection of open-source tools for Arabic natural language processing in Python. CAMeL Tools currently provides utilities for pre-processing, morphological modeling, Dialect Identification, Named Entity Recognition and Sentiment Analysis. In this paper, we describe the design of CAMeL Tools and the functionalities it provides.",
+                language = "English",
+                ISBN = "979-10-95546-34-4",
+            }""",
+        }
 
     def get_data_sample(self):
         return {

--- a/llmebench/datasets/ARCD.py
+++ b/llmebench/datasets/ARCD.py
@@ -7,13 +7,15 @@ class ARCDDataset(SQuADBase):
     def __init__(self, **kwargs):
         super(ARCDDataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """
-        @misc{mozannar2019neural,
-            title={Neural Arabic Question Answering}, 
-            author={Hussein Mozannar and Karl El Hajal and Elie Maamary and Hazem Hajj},
-            year={2019},
-            eprint={1906.05394},
-            archivePrefix={arXiv},
-            primaryClass={cs.CL}
-        }"""
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@misc{mozannar2019neural,
+                title={Neural Arabic Question Answering},
+                author={Hussein Mozannar and Karl El Hajal and Elie Maamary and Hazem Hajj},
+                year={2019},
+                eprint={1906.05394},
+                archivePrefix={arXiv},
+                primaryClass={cs.CL}
+            }""",
+        }

--- a/llmebench/datasets/Adult.py
+++ b/llmebench/datasets/Adult.py
@@ -5,22 +5,23 @@ class AdultDataset(DatasetBase):
     def __init__(self, **kwargs):
         super(AdultDataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """
-        @inproceedings{mubarak-etal-2021-adult,
-            title = "Adult Content Detection on {A}rabic {T}witter: Analysis and Experiments",
-            author = "Mubarak, Hamdy  and
-              Hassan, Sabit  and
-              Abdelali, Ahmed",
-            booktitle = "Proceedings of the Sixth Arabic Natural Language Processing Workshop",
-            month = apr,
-            year = "2021",
-            address = "Kyiv, Ukraine (Virtual)",
-            publisher = "Association for Computational Linguistics",
-            url = "https://aclanthology.org/2021.wanlp-1.14",
-            pages = "136--144", 
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@inproceedings{mubarak-etal-2021-adult,
+                title = "Adult Content Detection on {A}rabic {T}witter: Analysis and Experiments",
+                author = "Mubarak, Hamdy  and
+                  Hassan, Sabit  and
+                  Abdelali, Ahmed",
+                booktitle = "Proceedings of the Sixth Arabic Natural Language Processing Workshop",
+                month = apr,
+                year = "2021",
+                address = "Kyiv, Ukraine (Virtual)",
+                publisher = "Association for Computational Linguistics",
+                url = "https://aclanthology.org/2021.wanlp-1.14",
+                pages = "136--144",
+            }""",
         }
-        """
 
     def get_data_sample(self):
         return {"input": "نص عادي", "label": "NOT_ADULT"}

--- a/llmebench/datasets/Aqmar.py
+++ b/llmebench/datasets/Aqmar.py
@@ -45,8 +45,10 @@ class AqmarDataset(DatasetBase):
             ],
         )
 
-    def citation(self):
-        return """@inproceedings{mohit-etal-2012-recall,
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@inproceedings{mohit-etal-2012-recall,
                 title = \"Recall-Oriented Learning of Named Entities in {A}rabic {W}ikipedia\",
                 author = \"Mohit, Behrang  and
                 Schneider, Nathan  and
@@ -60,8 +62,8 @@ class AqmarDataset(DatasetBase):
                 publisher = \"Association for Computational Linguistics\",
                 url = \"https://aclanthology.org/E12-1017\",
                 pages = \"162--173\",
-}
-        }"""
+            }""",
+        }
 
     def get_data_sample(self):
         return {

--- a/llmebench/datasets/ArSASSentiment.py
+++ b/llmebench/datasets/ArSASSentiment.py
@@ -5,12 +5,15 @@ class ArSASSentimentDataset(DatasetBase):
     def __init__(self, **kwargs):
         super(ArSASSentimentDataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """@inproceedings{Elmadany2018ArSASA,
-            title={ArSAS : An Arabic Speech-Act and Sentiment Corpus of Tweets},
-            author={AbdelRahim Elmadany and Hamdy Mubarak and Walid Magdy},
-            year={2018}
-        }"""
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@inproceedings{Elmadany2018ArSASA,
+                title={ArSAS : An Arabic Speech-Act and Sentiment Corpus of Tweets},
+                author={AbdelRahim Elmadany and Hamdy Mubarak and Walid Magdy},
+                year={2018}
+            }""",
+        }
 
     def get_data_sample(self):
         return {"input": "Tweet", "label": "Positive"}

--- a/llmebench/datasets/ArSarcasm.py
+++ b/llmebench/datasets/ArSarcasm.py
@@ -7,20 +7,23 @@ class ArSarcasmDataset(DatasetBase):
     def __init__(self, **kwargs):
         super(ArSarcasmDataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """@inproceedings{abu-farha-magdy-2020-arabic,
-            title = "From {A}rabic Sentiment Analysis to Sarcasm Detection: The {A}r{S}arcasm Dataset",
-            author = "Abu Farha, Ibrahim  and Magdy, Walid",
-            booktitle = "Proceedings of the 4th Workshop on Open-Source Arabic Corpora and Processing Tools, with a Shared Task on Offensive Language Detection",
-            month = may,
-            year = "2020",
-            address = "Marseille, France",
-            publisher = "European Language Resource Association",
-            url = "https://www.aclweb.org/anthology/2020.osact-1.5",
-            pages = "32--39",
-            language = "English",
-            ISBN = "979-10-95546-51-1",
-        }"""
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@inproceedings{abu-farha-magdy-2020-arabic,
+                title = "From {A}rabic Sentiment Analysis to Sarcasm Detection: The {A}r{S}arcasm Dataset",
+                author = "Abu Farha, Ibrahim  and Magdy, Walid",
+                booktitle = "Proceedings of the 4th Workshop on Open-Source Arabic Corpora and Processing Tools, with a Shared Task on Offensive Language Detection",
+                month = may,
+                year = "2020",
+                address = "Marseille, France",
+                publisher = "European Language Resource Association",
+                url = "https://www.aclweb.org/anthology/2020.osact-1.5",
+                pages = "32--39",
+                language = "English",
+                ISBN = "979-10-95546-51-1",
+            }""",
+        }
 
     def get_data_sample(self):
         return {"input": "A tweet", "label": "TRUE"}

--- a/llmebench/datasets/AraBench.py
+++ b/llmebench/datasets/AraBench.py
@@ -7,22 +7,25 @@ class AraBenchDataset(DatasetBase):
         self.src = src
         self.tgt = tgt
 
-    def citation(self):
-        return """@inproceedings{sajjad-etal-2020-arabench,
-            title = "{A}ra{B}ench: Benchmarking Dialectal {A}rabic-{E}nglish Machine Translation",
-            author = "Sajjad, Hassan  and
-              Abdelali, Ahmed  and
-              Durrani, Nadir  and
-              Dalvi, Fahim",
-            booktitle = "Proceedings of the 28th International Conference on Computational Linguistics",
-            month = dec,
-            year = "2020",
-            address = "Barcelona, Spain (Online)",
-            publisher = "International Committee on Computational Linguistics",
-            url = "https://aclanthology.org/2020.coling-main.447",
-            doi = "10.18653/v1/2020.coling-main.447",
-            pages = "5094--5107"
-        }"""
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@inproceedings{sajjad-etal-2020-arabench,
+                title = "{A}ra{B}ench: Benchmarking Dialectal {A}rabic-{E}nglish Machine Translation",
+                author = "Sajjad, Hassan  and
+                  Abdelali, Ahmed  and
+                  Durrani, Nadir  and
+                  Dalvi, Fahim",
+                booktitle = "Proceedings of the 28th International Conference on Computational Linguistics",
+                month = dec,
+                year = "2020",
+                address = "Barcelona, Spain (Online)",
+                publisher = "International Committee on Computational Linguistics",
+                url = "https://aclanthology.org/2020.coling-main.447",
+                doi = "10.18653/v1/2020.coling-main.447",
+                pages = "5094--5107"
+            }""",
+        }
 
     def get_data_sample(self):
         return {"input": "Sentence in language #1", "label": "Sentence in language #2"}

--- a/llmebench/datasets/ArabGend.py
+++ b/llmebench/datasets/ArabGend.py
@@ -5,13 +5,16 @@ class ArabGendDataset(DatasetBase):
     def __init__(self, **kwargs):
         super(ArabGendDataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """@article{mubarak2022arabgend,
-          title={ArabGend: Gender analysis and inference on {A}rabic Twitter},
-          author={Mubarak, Hamdy and Chowdhury, Shammur Absar and Alam, Firoj},
-          journal={arXiv preprint arXiv:2203.00271},
-          year={2022}
-        }"""
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@article{mubarak2022arabgend,
+              title={ArabGend: Gender analysis and inference on {A}rabic Twitter},
+              author={Mubarak, Hamdy and Chowdhury, Shammur Absar and Alam, Firoj},
+              journal={arXiv preprint arXiv:2203.00271},
+              year={2022}
+            }""",
+        }
 
     def get_data_sample(self):
         return {"input": "A name", "label": "m"}

--- a/llmebench/datasets/ArabicDiacritization.py
+++ b/llmebench/datasets/ArabicDiacritization.py
@@ -5,24 +5,27 @@ class ArabicDiacritizationDataset(DatasetBase):
     def __init__(self, **kwargs):
         super(ArabicDiacritizationDataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """@article{10.1145/3434235,
-            author = {Darwish, Kareem and Abdelali, Ahmed and Mubarak, Hamdy and Eldesouki, Mohamed},
-            title = {Arabic Diacritic Recovery Using a Feature-Rich BiLSTM Model},
-            year = {2021},
-            issue_date = {March 2021},
-            publisher = {Association for Computing Machinery},
-            address = {New York, NY, USA},
-            volume = {20},
-            number = {2},
-            issn = {2375-4699},
-            url = {https://doi.org/10.1145/3434235},
-            doi = {10.1145/3434235},
-            journal = {ACM Trans. Asian Low-Resour. Lang. Inf. Process.},
-            month = {apr},
-            articleno = {33},
-            numpages = {18},
-            }"""
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@article{10.1145/3434235,
+                author = {Darwish, Kareem and Abdelali, Ahmed and Mubarak, Hamdy and Eldesouki, Mohamed},
+                title = {Arabic Diacritic Recovery Using a Feature-Rich BiLSTM Model},
+                year = {2021},
+                issue_date = {March 2021},
+                publisher = {Association for Computing Machinery},
+                address = {New York, NY, USA},
+                volume = {20},
+                number = {2},
+                issn = {2375-4699},
+                url = {https://doi.org/10.1145/3434235},
+                doi = {10.1145/3434235},
+                journal = {ACM Trans. Asian Low-Resour. Lang. Inf. Process.},
+                month = {apr},
+                articleno = {33},
+                numpages = {18},
+            }""",
+        }
 
     def get_data_sample(self):
         return {

--- a/llmebench/datasets/ArabicPOS.py
+++ b/llmebench/datasets/ArabicPOS.py
@@ -5,25 +5,28 @@ class ArabicPOSDataset(DatasetBase):
     def __init__(self, **kwargs):
         super(ArabicPOSDataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """@inproceedings{samih-etal-2017-learning,
-            title = "Learning from Relatives: Unified Dialectal {A}rabic Segmentation",
-            author = "Samih, Younes  and
-              Eldesouki, Mohamed  and
-              Attia, Mohammed  and
-              Darwish, Kareem  and
-              Abdelali, Ahmed  and
-              Mubarak, Hamdy  and
-              Kallmeyer, Laura",
-            booktitle = "Proceedings of the 21st Conference on Computational Natural Language Learning ({C}o{NLL} 2017)",
-            month = aug,
-            year = "2017",
-            address = "Vancouver, Canada",
-            publisher = "Association for Computational Linguistics",
-            url = "https://aclanthology.org/K17-1043",
-            doi = "10.18653/v1/K17-1043",
-            pages = "432--441"
-        }"""
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@inproceedings{samih-etal-2017-learning,
+                title = "Learning from Relatives: Unified Dialectal {A}rabic Segmentation",
+                author = "Samih, Younes  and
+                  Eldesouki, Mohamed  and
+                  Attia, Mohammed  and
+                  Darwish, Kareem  and
+                  Abdelali, Ahmed  and
+                  Mubarak, Hamdy  and
+                  Kallmeyer, Laura",
+                booktitle = "Proceedings of the 21st Conference on Computational Natural Language Learning ({C}o{NLL} 2017)",
+                month = aug,
+                year = "2017",
+                address = "Vancouver, Canada",
+                publisher = "Association for Computational Linguistics",
+                url = "https://aclanthology.org/K17-1043",
+                doi = "10.18653/v1/K17-1043",
+                pages = "432--441"
+            }""",
+        }
 
     def get_data_sample(self):
         return {

--- a/llmebench/datasets/ArabicParsing.py
+++ b/llmebench/datasets/ArabicParsing.py
@@ -5,25 +5,28 @@ class ArabicParsingDataset(DatasetBase):
     def __init__(self, **kwargs):
         super(ArabicParsingDataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """@inproceedings{samih-etal-2017-learning,
-            title = "Learning from Relatives: Unified Dialectal {A}rabic Segmentation",
-            author = "Samih, Younes  and
-              Eldesouki, Mohamed  and
-              Attia, Mohammed  and
-              Darwish, Kareem  and
-              Abdelali, Ahmed  and
-              Mubarak, Hamdy  and
-              Kallmeyer, Laura",
-            booktitle = "Proceedings of the 21st Conference on Computational Natural Language Learning ({C}o{NLL} 2017)",
-            month = aug,
-            year = "2017",
-            address = "Vancouver, Canada",
-            publisher = "Association for Computational Linguistics",
-            url = "https://aclanthology.org/K17-1043",
-            doi = "10.18653/v1/K17-1043",
-            pages = "432--441"
-        }"""
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@inproceedings{samih-etal-2017-learning,
+                title = "Learning from Relatives: Unified Dialectal {A}rabic Segmentation",
+                author = "Samih, Younes  and
+                  Eldesouki, Mohamed  and
+                  Attia, Mohammed  and
+                  Darwish, Kareem  and
+                  Abdelali, Ahmed  and
+                  Mubarak, Hamdy  and
+                  Kallmeyer, Laura",
+                booktitle = "Proceedings of the 21st Conference on Computational Natural Language Learning ({C}o{NLL} 2017)",
+                month = aug,
+                year = "2017",
+                address = "Vancouver, Canada",
+                publisher = "Association for Computational Linguistics",
+                url = "https://aclanthology.org/K17-1043",
+                doi = "10.18653/v1/K17-1043",
+                pages = "432--441"
+            }""",
+        }
 
     def get_data_sample(self):
         return {

--- a/llmebench/datasets/ArabicSegmentation.py
+++ b/llmebench/datasets/ArabicSegmentation.py
@@ -5,25 +5,28 @@ class ArabicSegmentationDataset(DatasetBase):
     def __init__(self, **kwargs):
         super(ArabicSegmentationDataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """@inproceedings{samih-etal-2017-learning,
-            title = "Learning from Relatives: Unified Dialectal {A}rabic Segmentation",
-            author = "Samih, Younes  and
-              Eldesouki, Mohamed  and
-              Attia, Mohammed  and
-              Darwish, Kareem  and
-              Abdelali, Ahmed  and
-              Mubarak, Hamdy  and
-              Kallmeyer, Laura",
-            booktitle = "Proceedings of the 21st Conference on Computational Natural Language Learning ({C}o{NLL} 2017)",
-            month = aug,
-            year = "2017",
-            address = "Vancouver, Canada",
-            publisher = "Association for Computational Linguistics",
-            url = "https://aclanthology.org/K17-1043",
-            doi = "10.18653/v1/K17-1043",
-            pages = "432--441"
-        }"""
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@inproceedings{samih-etal-2017-learning,
+                title = "Learning from Relatives: Unified Dialectal {A}rabic Segmentation",
+                author = "Samih, Younes  and
+                  Eldesouki, Mohamed  and
+                  Attia, Mohammed  and
+                  Darwish, Kareem  and
+                  Abdelali, Ahmed  and
+                  Mubarak, Hamdy  and
+                  Kallmeyer, Laura",
+                booktitle = "Proceedings of the 21st Conference on Computational Natural Language Learning ({C}o{NLL} 2017)",
+                month = aug,
+                year = "2017",
+                address = "Vancouver, Canada",
+                publisher = "Association for Computational Linguistics",
+                url = "https://aclanthology.org/K17-1043",
+                doi = "10.18653/v1/K17-1043",
+                pages = "432--441"
+            }""",
+        }
 
     def get_data_sample(self):
         return {

--- a/llmebench/datasets/ArapTweet.py
+++ b/llmebench/datasets/ArapTweet.py
@@ -5,14 +5,16 @@ class ArapTweetDataset(DatasetBase):
     def __init__(self, **kwargs):
         super(ArapTweetDataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """@inproceedings{zaghouani2018arap,
-              title={Arap-Tweet: A Large Multi-Dialect Twitter Corpus for Gender, Age and Language Variety Identification},
-              author={Zaghouani, Wajdi and Charfi, Anis},
-              booktitle={Proceedings of the Eleventh International Conference on Language Resources and Evaluation (LREC 2018)},
-              year={2018}
-            }
-        """
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@inproceedings{zaghouani2018arap,
+                title={Arap-Tweet: A Large Multi-Dialect Twitter Corpus for Gender, Age and Language Variety Identification},
+                author={Zaghouani, Wajdi and Charfi, Anis},
+                booktitle={Proceedings of the Eleventh International Conference on Language Resources and Evaluation (LREC 2018)},
+                year={2018}
+            }""",
+        }
 
     def get_data_sample(self):
         return {"input": "A name", "label": "m"}

--- a/llmebench/datasets/Attentionworthy.py
+++ b/llmebench/datasets/Attentionworthy.py
@@ -10,17 +10,18 @@ class AttentionworthyDataset(DatasetBase):
     def get_data_sample(self):
         return {"input": "some tweet", "label": "no_not_interesting"}
 
-    def citation(self):
-        return """
-                @InProceedings{clef-checkthat:2022:task1,
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@InProceedings{clef-checkthat:2022:task1,
                 author = {Nakov, Preslav and Barr\\'{o}n-Cede\\~{n}o, Alberto and Da San Martino, Giovanni and Alam, Firoj and M\\'{\\i}guez, Rub\'{e}n and Caselli, Tommaso and Kutlu, Mucahid and Zaghouani, Wajdi and Li, Chengkai and Shaar, Shaden and Mubarak, Hamdy and Nikolov, Alex and Kartal, Yavuz Selim and Beltr\\'{a}n, Javier},
                 title = "Overview of the {CLEF}-2022 {CheckThat}! Lab Task 1 on Identifying Relevant Claims in Tweets",
                 year = {2022},
                 booktitle = "Working Notes of {CLEF} 2022---Conference and Labs of the Evaluation Forum",
                 series = {CLEF~'2022},
                 address = {Bologna, Italy},
-                }
-        """
+            }""",
+        }
 
     def load_data(self, data_path):
         data = []

--- a/llmebench/datasets/BanglaSentiment.py
+++ b/llmebench/datasets/BanglaSentiment.py
@@ -5,13 +5,14 @@ class BanglaSentimentDataset(DatasetBase):
     def __init__(self, **kwargs):
         super(BanglaSentimentDataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """
-            @article{alam2021review,
-              title={A Review of Bangla Natural Language Processing Tasks and the Utility of Transformer Models},
-              author={Alam, Firoj and Hasan, Md Arid and Alam, Tanvir and Khan, Akib and Tajrin, Janntatul and Khan, Naira and Chowdhury, Shammur Absar},
-              journal={arXiv preprint arXiv:2107.03844},
-              year={2021}
+    def metadata():
+        return {
+            "language": "bn",
+            "citation": """@article{alam2021review,
+                title={A Review of Bangla Natural Language Processing Tasks and the Utility of Transformer Models},
+                author={Alam, Firoj and Hasan, Md Arid and Alam, Tanvir and Khan, Akib and Tajrin, Janntatul and Khan, Naira and Chowdhury, Shammur Absar},
+                journal={arXiv preprint arXiv:2107.03844},
+                year={2021}
             }        
             @inproceedings{iccit2020Arid,
                 Author = {Md. Arid Hasan and Jannatul Tajrin and Shammur Absar Chowdhury and Firoj Alam},
@@ -20,8 +21,8 @@ class BanglaSentimentDataset(DatasetBase):
                 Title = {Sentiment Classification in Bangla Textual Content: A Comparative Study},
                 Year = {2020},
                 url={https://github.com/banglanlp/bangla-sentiment-classification},
-            }
-        """
+            }""",
+        }
 
     def get_data_sample(self):
         return {"input": "Tweet", "label": "Positive", "line_number": 0}

--- a/llmebench/datasets/Checkworthiness.py
+++ b/llmebench/datasets/Checkworthiness.py
@@ -15,18 +15,18 @@ class CheckworthinessDataset(DatasetBase):
             "line_number": 0,
         }
 
-    def citation(self):
-        return """
-                @inproceedings{nakov2022overview,
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@inproceedings{nakov2022overview,
                   title={Overview of the clef--2022 checkthat! lab on fighting the covid-19 infodemic and fake news detection},
                   author={Nakov, Preslav and Barr{\\'o}n-Cede{\\~n}o, Alberto and da San Martino, Giovanni and Alam, Firoj and Stru{\\ss}, Julia Maria and Mandl, Thomas and M{\\'\\i}guez, Rub{\\'e}n and Caselli, Tommaso and Kutlu, Mucahid and Zaghouani, Wajdi and others},
                   booktitle={Experimental IR Meets Multilinguality, Multimodality, and Interaction: 13th International Conference of the CLEF Association, CLEF 2022, Bologna, Italy, September 5--8, 2022, Proceedings},
                   pages={495--520},
                   year={2022},
                   organization={Springer}
-                }
-
-        """
+            }""",
+        }
 
     def load_data(self, data_path):
         data = []

--- a/llmebench/datasets/Claim.py
+++ b/llmebench/datasets/Claim.py
@@ -7,13 +7,16 @@ class CovidClaimDataset(DatasetBase):
     def __init__(self, **kwargs):
         super(CovidClaimDataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """@inproceedings{nakov2022overview,
-                    title={Overview of the CLEF-2022 CheckThat! lab task 1 on identifying relevant claims in tweets},
-                    author={Nakov, Preslav and Barr{\\o}n-Cede{\\~n}o, Alberto and Da San Martino, Giovanni and Alam, Firoj and Kutlu, Mucahid and Zaghouani, Wajdi and Li, Chengkai and Shaar, Shaden and Mubarak, Hamdy and Nikolov, Alex},
-                     year={2022},
-                    booktitle={Proceedings of the Working Notes of CLEF 2022 - Conference and Labs of the Evaluation Forum}
-                }"""
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@inproceedings{nakov2022overview,
+                title={Overview of the CLEF-2022 CheckThat! lab task 1 on identifying relevant claims in tweets},
+                author={Nakov, Preslav and Barr{\\o}n-Cede{\\~n}o, Alberto and Da San Martino, Giovanni and Alam, Firoj and Kutlu, Mucahid and Zaghouani, Wajdi and Li, Chengkai and Shaar, Shaden and Mubarak, Hamdy and Nikolov, Alex},
+                 year={2022},
+                booktitle={Proceedings of the Working Notes of CLEF 2022 - Conference and Labs of the Evaluation Forum}
+            }""",
+        }
 
     def get_data_sample(self):
         return {"input": "Tweet", "label": "1"}

--- a/llmebench/datasets/DialectADI.py
+++ b/llmebench/datasets/DialectADI.py
@@ -10,10 +10,11 @@ class DialectADIDataset(DatasetBase):
     def get_data_sample(self):
         return {"input": "some tweet", "label": "no_not_interesting"}
 
-    def citation(self):
-        return """
-                TO DO: in house dataset
-        """
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """TO DO: in house dataset""",
+        }
 
     def load_data(self, data_path):
         data = []

--- a/llmebench/datasets/Emotion.py
+++ b/llmebench/datasets/Emotion.py
@@ -5,15 +5,18 @@ class EmotionDataset(DatasetBase):
     def __init__(self, **kwargs):
         super(EmotionDataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """@misc{hassan2022crosslingual,
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@misc{hassan2022crosslingual,
                 title={Cross-lingual Emotion Detection}, 
                 author={Sabit Hassan and Shaden Shaar and Kareem Darwish},
                 year={2022},
                 eprint={2106.06017},
                 archivePrefix={arXiv},
                 primaryClass={cs.CL}
-                }"""
+            }""",
+        }
 
     def get_data_sample(self):
         return {"input": "Tweet", "label": [0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0]}

--- a/llmebench/datasets/FactualityCOVID19.py
+++ b/llmebench/datasets/FactualityCOVID19.py
@@ -10,9 +10,10 @@ class FactualityCOVID19Dataset(DatasetBase):
     def get_data_sample(self):
         return {"input": "some tweet", "label": "no"}
 
-    def citation(self):
-        return """
-                @inproceedings{alam-etal-2021-fighting-covid,
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@inproceedings{alam-etal-2021-fighting-covid,
                 title = "Fighting the {COVID}-19 Infodemic: Modeling the Perspective of Journalists, Fact-Checkers, Social Media Platforms, Policy Makers, and the Society",
                 author = "Alam, Firoj  and
                   Shaar, Shaden  and
@@ -39,9 +40,8 @@ class FactualityCOVID19Dataset(DatasetBase):
                 url = "https://aclanthology.org/2021.findings-emnlp.56",
                 doi = "10.18653/v1/2021.findings-emnlp.56",
                 pages = "611--649",
-                
-            }
-        """
+            }""",
+        }
 
     def load_data(self, data_path):
         data = []

--- a/llmebench/datasets/FactualityKhouja20.py
+++ b/llmebench/datasets/FactualityKhouja20.py
@@ -7,14 +7,16 @@ class FactualityKhouja20Dataset(DatasetBase):
     def __init__(self, **kwargs):
         super(FactualityKhouja20Dataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """
-        @article{khouja2020stance,
-            title={Stance prediction and claim verification: An Arabic perspective},
-            author={Khouja, Jude},
-            journal={arXiv preprint arXiv:2005.10410},
-            year={2020}
-        }"""
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@article{khouja2020stance,
+                title={Stance prediction and claim verification: An Arabic perspective},
+                author={Khouja, Jude},
+                journal={arXiv preprint arXiv:2005.10410},
+                year={2020}
+            }""",
+        }
 
     def get_data_sample(self):
         return {"input": "الجملة بالعربية", "label": "true", "line_number": "1"}

--- a/llmebench/datasets/FactualityUnifiedFC.py
+++ b/llmebench/datasets/FactualityUnifiedFC.py
@@ -5,20 +5,21 @@ class FactualityUnifiedFCDataset(DatasetBase):
     def __init__(self, **kwargs):
         super(FactualityUnifiedFCDataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """
-                @inproceedings{baly2018integrating,
-                  title = "Integrating Stance Detection and Fact Checking in a Unified Corpus",
-                    author = "Baly, Ramy  and
-                      Mohtarami, Mitra  and
-                      Glass, James  and
-                      M{\\`a}rquez, Llu{\\'\\i}s  and
-                      Moschitti, Alessandro  and
-                      Nakov, Preslav",
-                    booktitle = "Proceedings of the 2018 Conference of the North {A}merican Chapter of the Association for Computational Linguistics: Human Language Technologies, Volume 2 (Short Papers)",
-                    year = "2018",
-                }
-        """
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@inproceedings{baly2018integrating,
+                title = "Integrating Stance Detection and Fact Checking in a Unified Corpus",
+                author = "Baly, Ramy  and
+                  Mohtarami, Mitra  and
+                  Glass, James  and
+                  M{\\`a}rquez, Llu{\\'\\i}s  and
+                  Moschitti, Alessandro  and
+                  Nakov, Preslav",
+                booktitle = "Proceedings of the 2018 Conference of the North {A}merican Chapter of the Association for Computational Linguistics: Human Language Technologies, Volume 2 (Short Papers)",
+                year = "2018",
+            }""",
+        }
 
     def get_data_sample(self):
         return {"input": "الجملة الاولى", "label": "agree", "input_id": "id"}

--- a/llmebench/datasets/Harmful.py
+++ b/llmebench/datasets/Harmful.py
@@ -7,13 +7,16 @@ class CovidHarmfulDataset(DatasetBase):
     def __init__(self, **kwargs):
         super(CovidHarmfulDataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """@inproceedings{nakov2022overview,
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@inproceedings{nakov2022overview,
                     title={Overview of the CLEF-2022 CheckThat! lab task 1 on identifying relevant claims in tweets},
                     author={Nakov, Preslav and Barr{\\'o}n-Cede{\\~n}o, Alberto and Da San Martino, Giovanni and Alam, Firoj and Kutlu, Mucahid and Zaghouani, Wajdi and Li, Chengkai and Shaar, Shaden and Mubarak, Hamdy and Nikolov, Alex},
                      year={2022},
                     booktitle={Proceedings of the Working Notes of CLEF 2022 - Conference and Labs of the Evaluation Forum}
-                }"""
+                }""",
+        }
 
     def get_data_sample(self):
         return {"input": "Tweet", "label": "1"}

--- a/llmebench/datasets/HateSpeech.py
+++ b/llmebench/datasets/HateSpeech.py
@@ -5,14 +5,17 @@ class HateSpeechDataset(DatasetBase):
     def __init__(self, **kwargs):
         super(HateSpeechDataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """@inproceedings{mubarak2020overview,
-          title={Overview of OSACT4 Arabic offensive language detection shared task},
-          author={Mubarak, Hamdy and Darwish, Kareem and Magdy, Walid and Elsayed, Tamer and Al-Khalifa, Hend},
-          booktitle={Proceedings of the 4th Workshop on open-source arabic corpora and processing tools, with a shared task on offensive language detection},
-          pages={48--52},
-          year={2020}
-        }"""
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@inproceedings{mubarak2020overview,
+                title={Overview of OSACT4 Arabic offensive language detection shared task},
+                author={Mubarak, Hamdy and Darwish, Kareem and Magdy, Walid and Elsayed, Tamer and Al-Khalifa, Hend},
+                booktitle={Proceedings of the 4th Workshop on open-source arabic corpora and processing tools, with a shared task on offensive language detection},
+                pages={48--52},
+                year={2020}
+            }""",
+        }
 
     def get_data_sample(self):
         return {"input": "ايه اللي انت بتقوله ده يا اوروبي يا متخلف", "label": "HS"}

--- a/llmebench/datasets/Lemmatization.py
+++ b/llmebench/datasets/Lemmatization.py
@@ -5,14 +5,16 @@ class LemmatizationDataset(DatasetBase):
     def __init__(self, **kwargs):
         super(LemmatizationDataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """@inproceedings{mubarak2018build,
-          title={Build Fast and Accurate Lemmatization for Arabic},
-          author={Mubarak, Hamdy},
-          booktitle={Proceedings of the Eleventh International Conference on Language Resources and Evaluation (LREC 2018)},
-          year={2018}
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@inproceedings{mubarak2018build,
+                title={Build Fast and Accurate Lemmatization for Arabic},
+                author={Mubarak, Hamdy},
+                booktitle={Proceedings of the Eleventh International Conference on Language Resources and Evaluation (LREC 2018)},
+                year={2018}
+            }""",
         }
-        """
 
     def get_data_sample(self):
         return {

--- a/llmebench/datasets/Location.py
+++ b/llmebench/datasets/Location.py
@@ -5,15 +5,17 @@ class LocationDataset(DatasetBase):
     def __init__(self, **kwargs):
         super(LocationDataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """@inproceedings{mubarak2021ul2c,
-              title={UL2C: Mapping user locations to countries on Arabic Twitter},
-              author={Mubarak, Hamdy and Hassan, Sabit},
-              booktitle={Proceedings of the Sixth Arabic Natural Language Processing Workshop},
-              pages={145--153},
-              year={2021}
-            }
-        }"""
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@inproceedings{mubarak2021ul2c,
+                title={UL2C: Mapping user locations to countries on Arabic Twitter},
+                author={Mubarak, Hamdy and Hassan, Sabit},
+                booktitle={Proceedings of the Sixth Arabic Natural Language Processing Workshop},
+                pages={145--153},
+                year={2021}
+            }""",
+        }
 
     def get_data_sample(self):
         return {"input": "Doha, Qatar", "label": "QA"}

--- a/llmebench/datasets/MGBWords.py
+++ b/llmebench/datasets/MGBWords.py
@@ -5,12 +5,26 @@ class MGBWordsDataset(DatasetBase):
     def __init__(self, **kwargs):
         super(MGBWordsDataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """ Hamdy Mubarak, Amir Hussein, Shammur Absar Chowdhury, and Ahmed Ali. 2021. 
-                QASR: QCRI Aljazeera Speech Resource A Large Scale Annotated Arabic Speech Corpus. 
-                In Proceedings of the 59th Annual Meeting of the Association for Computational Linguistics 
-                and the 11th International Joint Conference on Natural Language Processing (Volume 1: Long Papers), 
-                pages 2274–2285, Online. Association for Computational Linguistics. """
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@inproceedings{mubarak-etal-2021-qasr,
+                title = "{QASR}: {QCRI} Aljazeera Speech Resource A Large Scale Annotated {A}rabic Speech Corpus",
+                author = "Mubarak, Hamdy  and
+                  Hussein, Amir  and
+                  Chowdhury, Shammur Absar  and
+                  Ali, Ahmed",
+                booktitle = "Proceedings of the 59th Annual Meeting of the Association for Computational Linguistics and the 11th International Joint Conference on Natural Language Processing (Volume 1: Long Papers)",
+                month = aug,
+                year = "2021",
+                address = "Online",
+                publisher = "Association for Computational Linguistics",
+                url = "https://aclanthology.org/2021.acl-long.177",
+                doi = "10.18653/v1/2021.acl-long.177",
+                pages = "2274--2285",
+                abstract = "We introduce the largest transcribed Arabic speech corpus, QASR, collected from the broadcast domain. This multi-dialect speech dataset contains 2,000 hours of speech sampled at 16kHz crawled from Aljazeera news channel. The dataset is released with lightly supervised transcriptions, aligned with the audio segments. Unlike previous datasets, QASR contains linguistically motivated segmentation, punctuation, speaker information among others. QASR is suitable for training and evaluating speech recognition systems, acoustics- and/or linguistics- based Arabic dialect identification, punctuation restoration, speaker identification, speaker linking, and potentially other NLP modules for spoken data. In addition to QASR transcription, we release a dataset of 130M words to aid in designing and training a better language model. We show that end-to-end automatic speech recognition trained on QASR reports a competitive word error rate compared to the previous MGB-2 corpus. We report baseline results for downstream natural language processing tasks such as named entity recognition using speech transcript. We also report the first baseline for Arabic punctuation restoration. We make the corpus available for the research community.",
+            }""",
+        }
 
     def get_data_sample(self):
         return {"input": "sentence", "label": "named entity labels are here"}

--- a/llmebench/datasets/MLQA.py
+++ b/llmebench/datasets/MLQA.py
@@ -7,9 +7,13 @@ class MLQADataset(SQuADBase):
     def __init__(self, **kwargs):
         super(MLQADataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """ @article{lewis2019mlqa,
-        title=MLQA: Evaluating Cross-lingual Extractive Question Answering,
-        author={Lewis, Patrick and Ouguz, Barlas and Rinott, Ruty and Riedel, Sebastian and Schwenk, Holger},
-        journal={arXiv preprint arXiv:1910.07475},
-        year={2019} """
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@article{lewis2019mlqa,
+                title=MLQA: Evaluating Cross-lingual Extractive Question Answering,
+                author={Lewis, Patrick and Ouguz, Barlas and Rinott, Ruty and Riedel, Sebastian and Schwenk, Holger},
+                journal={arXiv preprint arXiv:1910.07475},
+                year={2019}
+            }""",
+        }

--- a/llmebench/datasets/NameInfo.py
+++ b/llmebench/datasets/NameInfo.py
@@ -5,10 +5,12 @@ class NameInfoDataset(DatasetBase):
     def __init__(self, **kwargs):
         super(NameInfoDataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """@inproceedings{Under review...}
-            }
-        }"""
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@inproceedings{Under review...}
+            }""",
+        }
 
     def get_data_sample(self):
         return {"input": "جورج واشنطن", "label": "GB"}

--- a/llmebench/datasets/NewsCatASND.py
+++ b/llmebench/datasets/NewsCatASND.py
@@ -10,9 +10,10 @@ class NewsCatASNDDataset(DatasetBase):
     def get_data_sample(self):
         return {"input": "some tweet", "label": "crime-war-conflict"}
 
-    def citation(self):
-        return """
-                @inproceedings{chowdhury-etal-2020-improving-arabic,
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@inproceedings{chowdhury-etal-2020-improving-arabic,
                 title = "Improving {A}rabic Text Categorization Using Transformer Training Diversification",
                 author = "Chowdhury, Shammur Absar  and
                   Abdelali, Ahmed  and
@@ -27,8 +28,8 @@ class NewsCatASNDDataset(DatasetBase):
                 publisher = "Association for Computational Linguistics",
                 url = "https://aclanthology.org/2020.wanlp-1.21",
                 pages = "226--236",                
-            }
-        """
+            }""",
+        }
 
     def load_data(self, data_path):
         data = []

--- a/llmebench/datasets/NewsCatAkhbarona.py
+++ b/llmebench/datasets/NewsCatAkhbarona.py
@@ -10,18 +10,19 @@ class NewsCatAkhbaronaDataset(DatasetBase):
     def get_data_sample(self):
         return {"input": "some tweet", "label": "checkworthy"}
 
-    def citation(self):
-        return """
-                @article{einea2019sanad,
-                  title={Sanad: Single-label {A}rabic news articles dataset for automatic text categorization},
-                  author={Einea, Omar and Elnagar, Ashraf and Al Debsi, Ridhwan},
-                  journal={Data in brief},
-                  volume={25},
-                  pages={104076},
-                  year={2019},
-                  publisher={Elsevier}
-                }
-        """
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@article{einea2019sanad,
+                title={Sanad: Single-label {A}rabic news articles dataset for automatic text categorization},
+                author={Einea, Omar and Elnagar, Ashraf and Al Debsi, Ridhwan},
+                journal={Data in brief},
+                volume={25},
+                pages={104076},
+                year={2019},
+                publisher={Elsevier}
+            }""",
+        }
 
     def load_data(self, data_path):
         data = []

--- a/llmebench/datasets/NewsCatAlArabiya.py
+++ b/llmebench/datasets/NewsCatAlArabiya.py
@@ -10,18 +10,19 @@ class NewsCatAlArabiyaDataset(DatasetBase):
     def get_data_sample(self):
         return {"input": "some tweet", "label": "checkworthy"}
 
-    def citation(self):
-        return """
-                @article{einea2019sanad,
-                  title={Sanad: Single-label {A}rabic news articles dataset for automatic text categorization},
-                  author={Einea, Omar and Elnagar, Ashraf and Al Debsi, Ridhwan},
-                  journal={Data in brief},
-                  volume={25},
-                  pages={104076},
-                  year={2019},
-                  publisher={Elsevier}
-                }
-        """
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@article{einea2019sanad,
+                title={Sanad: Single-label {A}rabic news articles dataset for automatic text categorization},
+                author={Einea, Omar and Elnagar, Ashraf and Al Debsi, Ridhwan},
+                journal={Data in brief},
+                volume={25},
+                pages={104076},
+                year={2019},
+                publisher={Elsevier}
+            }""",
+        }
 
     def load_data(self, data_path):
         data = []

--- a/llmebench/datasets/NewsCatAlKhaleej.py
+++ b/llmebench/datasets/NewsCatAlKhaleej.py
@@ -10,18 +10,19 @@ class NewsCatAlKhaleejDataset(DatasetBase):
     def get_data_sample(self):
         return {"input": "some tweet", "label": "checkworthy"}
 
-    def citation(self):
-        return """
-                @article{einea2019sanad,
-                  title={Sanad: Single-label {A}rabic news articles dataset for automatic text categorization},
-                  author={Einea, Omar and Elnagar, Ashraf and Al Debsi, Ridhwan},
-                  journal={Data in brief},
-                  volume={25},
-                  pages={104076},
-                  year={2019},
-                  publisher={Elsevier}
-                }
-        """
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@article{einea2019sanad,
+                title={Sanad: Single-label {A}rabic news articles dataset for automatic text categorization},
+                author={Einea, Omar and Elnagar, Ashraf and Al Debsi, Ridhwan},
+                journal={Data in brief},
+                volume={25},
+                pages={104076},
+                year={2019},
+                publisher={Elsevier}
+            }""",
+        }
 
     def load_data(self, data_path):
         data = []

--- a/llmebench/datasets/Offensive.py
+++ b/llmebench/datasets/Offensive.py
@@ -5,13 +5,16 @@ class OffensiveDataset(DatasetBase):
     def __init__(self, **kwargs):
         super(OffensiveDataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """@article{zampieri2020semeval,
-          title={SemEval-2020 task 12: Multilingual offensive language identification in social media (OffensEval 2020)},
-          author={Zampieri, Marcos and Nakov, Preslav and Rosenthal, Sara and Atanasova, Pepa and Karadzhov, Georgi and Mubarak, Hamdy and Derczynski, Leon and Pitenis, ...},
-          journal={arXiv preprint arXiv:2006.07235},
-          year={2020}
-        }"""
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@article{zampieri2020semeval,
+                title={SemEval-2020 task 12: Multilingual offensive language identification in social media (OffensEval 2020)},
+                author={Zampieri, Marcos and Nakov, Preslav and Rosenthal, Sara and Atanasova, Pepa and Karadzhov, Georgi and Mubarak, Hamdy and Derczynski, Leon and Pitenis, ...},
+                journal={arXiv preprint arXiv:2006.07235},
+                year={2020}
+            }""",
+        }
 
     def get_data_sample(self):
         return {"input": "@USER يلا يا خوخة يا مهزئة ع دراستك", "label": "OFF"}

--- a/llmebench/datasets/Propaganda.py
+++ b/llmebench/datasets/Propaganda.py
@@ -11,10 +11,13 @@ class PropagandaTweetDataset(DatasetBase):
         self.techniques_path = Path(techniques_path) if techniques_path else None
         super(PropagandaTweetDataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """@article{wanlp2023,
-          year={2023}
-        }"""
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@article{wanlp2023,
+                year={2023}
+            }""",
+        }
 
     def get_data_sample(self):
         return {"input": "Tweet", "label": ["no technique"]}

--- a/llmebench/datasets/PropagandaSemEval23.py
+++ b/llmebench/datasets/PropagandaSemEval23.py
@@ -11,25 +11,26 @@ class PropagandaSemEval23Dataset(DatasetBase):
         self.techniques_path = Path(techniques_path) if techniques_path else None
         super(PropagandaSemEval23Dataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """
-        @inproceedings{piskorski-etal-2023-semeval,
-            title = "{S}em{E}val-2023 Task 3: Detecting the Category, the Framing, and the Persuasion Techniques in Online News in a Multi-lingual Setup",
-            author = "Piskorski, Jakub  and
-              Stefanovitch, Nicolas  and
-              Da San Martino, Giovanni  and
-              Nakov, Preslav",
-            booktitle = "Proceedings of the 17th International Workshop on Semantic Evaluation (SemEval-2023)",
-            month = jul,
-            year = "2023",
-            address = "Toronto, Canada",
-            publisher = "Association for Computational Linguistics",
-            url = "https://aclanthology.org/2023.semeval-1.317",
-            doi = "10.18653/v1/2023.semeval-1.317",
-            pages = "2343--2361",
-            abstract = "We describe SemEval-2023 task 3 on Detecting the Category, the Framing, and the Persuasion Techniques in Online News in a Multilingual Setup: the dataset, the task organization process, the evaluation setup, the results, and the participating systems. The task focused on news articles in nine languages (six known to the participants upfront: English, French, German, Italian, Polish, and Russian), and three additional ones revealed to the participants at the testing phase: Spanish, Greek, and Georgian). The task featured three subtasks: (1) determining the genre of the article (opinion, reporting, or satire), (2) identifying one or more frames used in an article from a pool of 14 generic frames, and (3) identify the persuasion techniques used in each paragraph of the article, using a taxonomy of 23 persuasion techniques. This was a very popular task: a total of 181 teams registered to participate, and 41 eventually made an official submission on the test set.",
-        }        
-        """
+    def metadata():
+        return {
+            "language": "multilingual",
+            "citation": """@inproceedings{piskorski-etal-2023-semeval,
+                title = "{S}em{E}val-2023 Task 3: Detecting the Category, the Framing, and the Persuasion Techniques in Online News in a Multi-lingual Setup",
+                author = "Piskorski, Jakub  and
+                  Stefanovitch, Nicolas  and
+                  Da San Martino, Giovanni  and
+                  Nakov, Preslav",
+                booktitle = "Proceedings of the 17th International Workshop on Semantic Evaluation (SemEval-2023)",
+                month = jul,
+                year = "2023",
+                address = "Toronto, Canada",
+                publisher = "Association for Computational Linguistics",
+                url = "https://aclanthology.org/2023.semeval-1.317",
+                doi = "10.18653/v1/2023.semeval-1.317",
+                pages = "2343--2361",
+                abstract = "We describe SemEval-2023 task 3 on Detecting the Category, the Framing, and the Persuasion Techniques in Online News in a Multilingual Setup: the dataset, the task organization process, the evaluation setup, the results, and the participating systems. The task focused on news articles in nine languages (six known to the participants upfront: English, French, German, Italian, Polish, and Russian), and three additional ones revealed to the participants at the testing phase: Spanish, Greek, and Georgian). The task featured three subtasks: (1) determining the genre of the article (opinion, reporting, or satire), (2) identifying one or more frames used in an article from a pool of 14 generic frames, and (3) identify the persuasion techniques used in each paragraph of the article, using a taxonomy of 23 persuasion techniques. This was a very popular task: a total of 181 teams registered to participate, and 41 eventually made an official submission on the test set.",
+            }""",
+        }
 
     def get_data_sample(self):
         return {"input": "text", "label": ["no_technique"], "line_number": 0}

--- a/llmebench/datasets/QADI.py
+++ b/llmebench/datasets/QADI.py
@@ -5,15 +5,17 @@ class QADIDataset(DatasetBase):
     def __init__(self, **kwargs):
         super(QADIDataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """@inproceedings{abdelali2021qadi,
-          title={QADI: Arabic dialect identification in the wild},
-          author={Abdelali, Ahmed and Mubarak, Hamdy and Samih, Younes and Hassan, Sabit and Darwish, Kareem},
-          booktitle={Proceedings of the Sixth Arabic Natural Language Processing Workshop},
-          pages={1--10},
-          year={2021}
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@inproceedings{abdelali2021qadi,
+                title={QADI: Arabic dialect identification in the wild},
+                author={Abdelali, Ahmed and Mubarak, Hamdy and Samih, Younes and Hassan, Sabit and Darwish, Kareem},
+                booktitle={Proceedings of the Sixth Arabic Natural Language Processing Workshop},
+                pages={1--10},
+                year={2021}
+            }""",
         }
-        """
 
     def get_data_sample(self):
         return {"input": "طب ماتمشي هو حد ماسك فيك", "label": "EG"}

--- a/llmebench/datasets/STSArSemEval17Track1.py
+++ b/llmebench/datasets/STSArSemEval17Track1.py
@@ -5,15 +5,17 @@ class STSArSemEval17Track1Dataset(DatasetBase):
     def __init__(self, **kwargs):
         super(STSArSemEval17Track1Dataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """
-        @inproceedings{cer2017semeval,
-            title={SemEval-2017 Task 1: Semantic Textual Similarity Multilingual and Cross-lingual Focused Evaluation},
-            author={Cer, Daniel and Diab, Mona and Agirre, Eneko E and Lopez-Gazpio, I{\~n}igo and Specia, Lucia},
-            booktitle={The 11th International Workshop on Semantic Evaluation (SemEval-2017)},
-            pages={1--14},
-            year={2017}
-        }"""
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@inproceedings{cer2017semeval,
+                title={SemEval-2017 Task 1: Semantic Textual Similarity Multilingual and Cross-lingual Focused Evaluation},
+                author={Cer, Daniel and Diab, Mona and Agirre, Eneko E and Lopez-Gazpio, I{\~n}igo and Specia, Lucia},
+                booktitle={The 11th International Workshop on Semantic Evaluation (SemEval-2017)},
+                pages={1--14},
+                year={2017}
+            }""",
+        }
 
     def get_data_sample(self):
         return {"input": "الجملة بالعربية\tالجملة بالعربية", "label": 1.2}

--- a/llmebench/datasets/STSArSemEval17Track2.py
+++ b/llmebench/datasets/STSArSemEval17Track2.py
@@ -5,15 +5,17 @@ class STSArSemEval17Track2Dataset(DatasetBase):
     def __init__(self, **kwargs):
         super(STSArSemEval17Track2Dataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """
-        @inproceedings{cer2017semeval,
-            title={SemEval-2017 Task 1: Semantic Textual Similarity Multilingual and Cross-lingual Focused Evaluation},
-            author={Cer, Daniel and Diab, Mona and Agirre, Eneko E and Lopez-Gazpio, I{\~n}igo and Specia, Lucia},
-            booktitle={The 11th International Workshop on Semantic Evaluation (SemEval-2017)},
-            pages={1--14},
-            year={2017}
-        }"""
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@inproceedings{cer2017semeval,
+                title={SemEval-2017 Task 1: Semantic Textual Similarity Multilingual and Cross-lingual Focused Evaluation},
+                author={Cer, Daniel and Diab, Mona and Agirre, Eneko E and Lopez-Gazpio, I{\~n}igo and Specia, Lucia},
+                booktitle={The 11th International Workshop on Semantic Evaluation (SemEval-2017)},
+                pages={1--14},
+                year={2017}
+            }""",
+        }
 
     def get_data_sample(self):
         return {"input": "الجملة بالعربية\tالجملة english", "label": 1.2}

--- a/llmebench/datasets/STSQ2Q.py
+++ b/llmebench/datasets/STSQ2Q.py
@@ -7,15 +7,17 @@ class Q2QSimDataset(DatasetBase):
     def __init__(self, **kwargs):
         super(Q2QSimDataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """
-        @inproceedings{seelawi2019nsurl,
-            title={NSURL-2019 task 8: Semantic question similarity in arabic},
-            author={Seelawi, Haitham and Mustafa, Ahmad and Al-Bataineh, Hesham and Farhan, Wael and Al-Natsheh, Hussein T},
-            booktitle={Proceedings of the First International Workshop on NLP Solutions for Under Resourced Languages (NSURL 2019) co-located with ICNLSP 2019-Short Papers},
-            pages={1--8},
-            year={2019}
-        }"""
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@inproceedings{seelawi2019nsurl,
+                title={NSURL-2019 task 8: Semantic question similarity in arabic},
+                author={Seelawi, Haitham and Mustafa, Ahmad and Al-Bataineh, Hesham and Farhan, Wael and Al-Natsheh, Hussein T},
+                booktitle={Proceedings of the First International Workshop on NLP Solutions for Under Resourced Languages (NSURL 2019) co-located with ICNLSP 2019-Short Papers},
+                pages={1--8},
+                year={2019}
+            }""",
+        }
 
     def get_data_sample(self):
         return {

--- a/llmebench/datasets/Spam.py
+++ b/llmebench/datasets/Spam.py
@@ -5,16 +5,18 @@ class SpamDataset(DatasetBase):
     def __init__(self, **kwargs):
         super(SpamDataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """@inproceedings{mubarak2020spam,
-          title={Spam detection on arabic twitter},
-          author={Mubarak, Hamdy and Abdelali, Ahmed and Hassan, Sabit and Darwish, Kareem},
-          booktitle={Social Informatics: 12th International Conference, SocInfo 2020, Pisa, Italy, October 6--9, 2020, Proceedings 12},
-          pages={237--251},
-          year={2020},
-          organization={Springer}
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@inproceedings{mubarak2020spam,
+                title={Spam detection on arabic twitter},
+                author={Mubarak, Hamdy and Abdelali, Ahmed and Hassan, Sabit and Darwish, Kareem},
+                booktitle={Social Informatics: 12th International Conference, SocInfo 2020, Pisa, Italy, October 6--9, 2020, Proceedings 12},
+                pages={237--251},
+                year={2020},
+                organization={Springer}
+            }""",
         }
-        """
 
     def get_data_sample(self):
         return {"input": "أختر قلباً وليسّ شكلاً..", "label": "__label__NOTADS"}

--- a/llmebench/datasets/StanceKhouja20.py
+++ b/llmebench/datasets/StanceKhouja20.py
@@ -5,14 +5,16 @@ class StanceKhouja20Dataset(DatasetBase):
     def __init__(self, **kwargs):
         super(StanceKhouja20Dataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """
-        @article{khouja2020stance,
-            title={Stance prediction and claim verification: An Arabic perspective},
-            author={Khouja, Jude},
-            journal={arXiv preprint arXiv:2005.10410},
-            year={2020}
-        }"""
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@article{khouja2020stance,
+                title={Stance prediction and claim verification: An Arabic perspective},
+                author={Khouja, Jude},
+                journal={arXiv preprint arXiv:2005.10410},
+                year={2020}
+            }""",
+        }
 
     def get_data_sample(self):
         return {

--- a/llmebench/datasets/StanceUnifiedFC.py
+++ b/llmebench/datasets/StanceUnifiedFC.py
@@ -10,20 +10,21 @@ class StanceUnifiedFCDataset(DatasetBase):
     def __init__(self, **kwargs):
         super(StanceUnifiedFCDataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """
-            @inproceedings{baly2018integrating,
-              title = "Integrating Stance Detection and Fact Checking in a Unified Corpus",
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@inproceedings{baly2018integrating,
+                title = "Integrating Stance Detection and Fact Checking in a Unified Corpus",
                 author = "Baly, Ramy  and
                   Mohtarami, Mitra  and
                   Glass, James  and
-                  M{\`a}rquez, Llu{\'\i}s  and
+                  M{\\`a}rquez, Llu{\\'\\i}s  and
                   Moschitti, Alessandro  and
                   Nakov, Preslav",
                 booktitle = "Proceedings of the 2018 Conference of the North {A}merican Chapter of the Association for Computational Linguistics: Human Language Technologies, Volume 2 (Short Papers)",
                 year = "2018",
-            }
-        """
+            }""",
+        }
 
     def get_data_sample(self):
         return {

--- a/llmebench/datasets/Subjectivity.py
+++ b/llmebench/datasets/Subjectivity.py
@@ -10,17 +10,18 @@ class SubjectivityDataset(DatasetBase):
     def get_data_sample(self):
         return {"input": "some tweet", "label": "SUBJ"}
 
-    def citation(self):
-        return """
-                @inproceedings{barron2023clef,
-                  title={The CLEF-2023 CheckThat! Lab: Checkworthiness, Subjectivity, Political Bias, Factuality, and Authority},
-                  author={Barr{\\'o}n-Cede{\\~n}o, Alberto and Alam, Firoj and Caselli, Tommaso and Da San Martino, Giovanni and Elsayed, Tamer and Galassi, Andrea and Haouari, Fatima and Ruggeri, Federico and Stru{\\ss}, Julia Maria and Nandi, Rabindra Nath and others},
-                  booktitle={Advances in Information Retrieval: 45th European Conference on Information Retrieval, ECIR 2023, Dublin, Ireland, April 2--6, 2023, Proceedings, Part III},
-                  pages={506--517},
-                  year={2023},
-                  organization={Springer}
-                }
-            """
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@inproceedings{barron2023clef,
+                title={The CLEF-2023 CheckThat! Lab: Checkworthiness, Subjectivity, Political Bias, Factuality, and Authority},
+                author={Barr{\\'o}n-Cede{\\~n}o, Alberto and Alam, Firoj and Caselli, Tommaso and Da San Martino, Giovanni and Elsayed, Tamer and Galassi, Andrea and Haouari, Fatima and Ruggeri, Federico and Stru{\\ss}, Julia Maria and Nandi, Rabindra Nath and others},
+                booktitle={Advances in Information Retrieval: 45th European Conference on Information Retrieval, ECIR 2023, Dublin, Ireland, April 2--6, 2023, Proceedings, Part III},
+                pages={506--517},
+                year={2023},
+                organization={Springer}
+            }""",
+        }
 
     def load_data(self, data_path):
         data = []

--- a/llmebench/datasets/TyDiQA.py
+++ b/llmebench/datasets/TyDiQA.py
@@ -7,10 +7,13 @@ class TyDiQADataset(SQuADBase):
     def __init__(self, **kwargs):
         super(TyDiQADataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """ @article{tydiqa,
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@article{tydiqa,
                 title   = {TyDi QA: A Benchmark for Information-Seeking Question Answering in Typologically Diverse Languages},
                 author  = {Jonathan H. Clark and Eunsol Choi and Michael Collins and Dan Garrette and Tom Kwiatkowski and Vitaly Nikolaev and Jennimaria Palomaki}
                 year    = {2020},
                 journal = {Transactions of the Association for Computational Linguistics}
-            } """
+            }""",
+        }

--- a/llmebench/datasets/XNLI.py
+++ b/llmebench/datasets/XNLI.py
@@ -7,22 +7,25 @@ class XNLIDataset(DatasetBase):
     def __init__(self, **kwargs):
         super(XNLIDataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """@InProceedings{conneau2018xnli,
-                  author = "Conneau, Alexis
-                        and Rinott, Ruty
-                        and Lample, Guillaume
-                        and Williams, Adina
-                        and Bowman, Samuel R.
-                        and Schwenk, Holger
-                        and Stoyanov, Veselin",
-                  title = "XNLI: Evaluating Cross-lingual Sentence Representations",
-                  booktitle = "Proceedings of the 2018 Conference on Empirical Methods
-                               in Natural Language Processing",
-                  year = "2018",
-                  publisher = "Association for Computational Linguistics",
-                  location = "Brussels, Belgium",
-                }"""
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@InProceedings{conneau2018xnli,
+                author = "Conneau, Alexis
+                    and Rinott, Ruty
+                    and Lample, Guillaume
+                    and Williams, Adina
+                    and Bowman, Samuel R.
+                    and Schwenk, Holger
+                    and Stoyanov, Veselin",
+                title = "XNLI: Evaluating Cross-lingual Sentence Representations",
+                booktitle = "Proceedings of the 2018 Conference on Empirical Methods
+                           in Natural Language Processing",
+                year = "2018",
+                publisher = "Association for Computational Linguistics",
+                location = "Brussels, Belgium",
+            }""",
+        }
 
     def get_data_sample(self):
         return {"input": "Test\tTest", "label": "neutral"}

--- a/llmebench/datasets/XQuAD.py
+++ b/llmebench/datasets/XQuAD.py
@@ -7,13 +7,16 @@ class XQuADDataset(SQuADBase):
     def __init__(self, **kwargs):
         super(XQuADDataset, self).__init__(**kwargs)
 
-    def citation(self):
-        return """@article{Artetxe:etal:2019,
-                    author={Mikel Artetxe and Sebastian Ruder and Dani Yogatama},
-                    title={On the cross-lingual transferability of monolingual representations},
-                    journal={CoRR},
-                    volume={abs/1910.11856},
-                    year={2019},
-                    archivePrefix={arXiv},
-                    eprint={1910.11856}
-            }"""
+    def metadata():
+        return {
+            "language": "ar",
+            "citation": """@article{Artetxe:etal:2019,
+                author={Mikel Artetxe and Sebastian Ruder and Dani Yogatama},
+                title={On the cross-lingual transferability of monolingual representations},
+                journal={CoRR},
+                volume={abs/1910.11856},
+                year={2019},
+                archivePrefix={arXiv},
+                eprint={1910.11856}
+            }""",
+        }

--- a/llmebench/datasets/dataset_base.py
+++ b/llmebench/datasets/dataset_base.py
@@ -13,8 +13,22 @@ class DatasetBase(ABC):
     def __init__(self, **kwargs):
         pass
 
+    @staticmethod
     @abstractmethod
-    def citation(self):
+    def metadata():
+        """
+        Must return a dictionary with the following keys:
+            "citation": str
+                bib-formatted citation for the dataset
+            "language": str|list
+                Can be one of:
+                    "multilingual"
+                    ["ar", "fr", "en"] # List of supported langauges
+                    "ar" # Single supported language
+                Languages should be identified by their IETF language tags
+            "download_url": str (optional)
+                URL to data to automatically download if not present
+        """
         pass
 
     @abstractmethod

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ python_requires = >=3.8
 
 [options.extras_require]
 dev =
+    langcodes==3.3.0
     pytest==7.3.1
     pytest-cov==4.1.0
     pytest-subtests==0.11.0

--- a/tests/datasets/test_metadata.py
+++ b/tests/datasets/test_metadata.py
@@ -1,0 +1,35 @@
+import inspect
+import unittest
+
+from pathlib import Path
+
+import llmebench.datasets as datasets
+
+from langcodes import tag_is_valid
+
+
+class TestDatasetMetadata(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Search for all implemented datasets
+        framework_dir = Path("llmebench")
+        cls.datasets = set(
+            [m[1] for m in inspect.getmembers(datasets, inspect.isclass)]
+        )
+
+    def test_dataset_exports(self):
+        "Test if all datasets export the required metadata"
+
+        for dataset in self.datasets:
+            self.assertIsInstance(dataset.metadata(), dict)
+            self.assertIn("citation", dataset.metadata())
+            self.assertIsInstance(dataset.metadata()["citation"], str)
+            self.assertIn("language", dataset.metadata())
+            self.assertIsInstance(dataset.metadata()["language"], (str, list))
+
+            languages = dataset.metadata()["language"]
+            if isinstance(languages, str):
+                languages = [languages]
+
+            for language in languages:
+                self.assertTrue(language == "multilingual" or tag_is_valid(language))


### PR DESCRIPTION
All datasets will now require implementing a static metadata(), which encompasses the older required citation() method, as well as other data like `download_url`, `language` etc.