### PR TITLE
Silence expected warnings while running tests

### DIFF
--- a/llmebench/datasets/STSArSemEval17Track1.py
+++ b/llmebench/datasets/STSArSemEval17Track1.py
@@ -10,7 +10,7 @@ class STSArSemEval17Track1Dataset(DatasetBase):
             "language": "ar",
             "citation": """@inproceedings{cer2017semeval,
                 title={SemEval-2017 Task 1: Semantic Textual Similarity Multilingual and Cross-lingual Focused Evaluation},
-                author={Cer, Daniel and Diab, Mona and Agirre, Eneko E and Lopez-Gazpio, I{\~n}igo and Specia, Lucia},
+                author={Cer, Daniel and Diab, Mona and Agirre, Eneko E and Lopez-Gazpio, I{\\~n}igo and Specia, Lucia},
                 booktitle={The 11th International Workshop on Semantic Evaluation (SemEval-2017)},
                 pages={1--14},
                 year={2017}

--- a/llmebench/datasets/STSArSemEval17Track2.py
+++ b/llmebench/datasets/STSArSemEval17Track2.py
@@ -10,7 +10,7 @@ class STSArSemEval17Track2Dataset(DatasetBase):
             "language": "ar",
             "citation": """@inproceedings{cer2017semeval,
                 title={SemEval-2017 Task 1: Semantic Textual Similarity Multilingual and Cross-lingual Focused Evaluation},
-                author={Cer, Daniel and Diab, Mona and Agirre, Eneko E and Lopez-Gazpio, I{\~n}igo and Specia, Lucia},
+                author={Cer, Daniel and Diab, Mona and Agirre, Eneko E and Lopez-Gazpio, I{\\~n}igo and Specia, Lucia},
                 booktitle={The 11th International Workshop on Semantic Evaluation (SemEval-2017)},
                 pages={1--14},
                 year={2017}

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,3 +46,8 @@ exclude = tests*
 
 [tool:pytest]
 testpaths = tests
+filterwarnings =
+    ignore::sklearn.exceptions.UndefinedMetricWarning
+    ignore:divide by zero:RuntimeWarning
+    ignore:Degrees of freedom:RuntimeWarning
+    ignore:invalid value encountered in multiply:RuntimeWarning


### PR DESCRIPTION
Add expected warnings such as `divide by 0`, `UnexpectedMetric` from sklearn etc, as these are expected when running the tests.