### PR TITLE
Add implementation specific tests for Dataset/Model/Task

### DIFF
--- a/llmebench/datasets/WANLP22T3Propaganda.py
+++ b/llmebench/datasets/WANLP22T3Propaganda.py
@@ -15,7 +15,7 @@ class WANLP22T3PropagandaDataset(DatasetBase):
         return {
             "language": "ar",
             "citation": """@inproceedings{alam2022overview,
-              title={Overview of the $\{$WANLP$\}$ 2022 Shared Task on Propaganda Detection in $\{$A$\}$ rabic},
+              title={Overview of the $\\{$WANLP$\\}$ 2022 Shared Task on Propaganda Detection in $\\{$A$\\}$ rabic},
               author={Alam, Firoj and Mubarak, Hamdy and Zaghouani, Wajdi and Da San Martino, Giovanni and Nakov, Preslav and others},
               booktitle={Proceedings of the The Seventh Arabic Natural Language Processing Workshop (WANLP)},
               pages={108--118},

--- a/tests/datasets/test_implementation.py
+++ b/tests/datasets/test_implementation.py
@@ -1,10 +1,11 @@
-import ast
 import inspect
 import unittest
 
 from pathlib import Path
 
 import llmebench.datasets as datasets
+
+from tests.utils import base_class_constructor_checker
 
 
 class TestDatasetImplementation(unittest.TestCase):
@@ -21,51 +22,4 @@ class TestDatasetImplementation(unittest.TestCase):
 
         for dataset in self.datasets:
             with self.subTest(msg=dataset.__name__):
-                tree = ast.parse(inspect.getsource(dataset))
-                constructors = list(
-                    n
-                    for n in ast.walk(tree)
-                    if isinstance(n, ast.FunctionDef) and n.name == "__init__"
-                )
-                self.assertLessEqual(
-                    len(constructors), 1, "Multiple constructors found"
-                )
-
-                if len(constructors) == 0:
-                    # No constructor, base will be called by default
-                    continue
-
-                constructor = constructors[0]
-
-                # Collect all function calls inside the constructor
-                fn_calls = list(
-                    n
-                    for n in ast.walk(constructor)
-                    if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
-                )
-
-                # For each, check if there is something of the form super(...).__init(...)
-                def is_base_constructor_call(node):
-                    fn_call = node.func
-                    if not isinstance(fn_call.value, ast.Call):
-                        return False
-                    if not fn_call.value.func.id == "super":
-                        return False
-                    if not fn_call.attr == "__init__":
-                        return False
-
-                    return True
-
-                filtered_fn_calls = list(filter(is_base_constructor_call, fn_calls))
-
-                self.assertEqual(
-                    len(filtered_fn_calls), 1, "Call to base class constructor missing"
-                )
-
-                self.assertTrue(
-                    any(
-                        isinstance(k.value, ast.Name) and k.value.id == "kwargs"
-                        for k in filtered_fn_calls[0].keywords
-                    ),
-                    "kwargs not passed to the base class constructor",
-                )
+                base_class_constructor_checker(dataset, self)

--- a/tests/datasets/test_implementation.py
+++ b/tests/datasets/test_implementation.py
@@ -1,0 +1,71 @@
+import ast
+import inspect
+import unittest
+
+from pathlib import Path
+
+import llmebench.datasets as datasets
+
+
+class TestDatasetImplementation(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Search for all implemented datasets
+        framework_dir = Path("llmebench")
+        cls.datasets = set(
+            [m[1] for m in inspect.getmembers(datasets, inspect.isclass)]
+        )
+
+    def test_base_constructor(self):
+        "Test if all datasets also call the base class constructor"
+
+        for dataset in self.datasets:
+            with self.subTest(msg=dataset.__name__):
+                tree = ast.parse(inspect.getsource(dataset))
+                constructors = list(
+                    n
+                    for n in ast.walk(tree)
+                    if isinstance(n, ast.FunctionDef) and n.name == "__init__"
+                )
+                self.assertLessEqual(
+                    len(constructors), 1, "Multiple constructors found"
+                )
+
+                if len(constructors) == 0:
+                    # No constructor, base will be called by default
+                    continue
+
+                constructor = constructors[0]
+
+                # Collect all function calls inside the constructor
+                fn_calls = list(
+                    n
+                    for n in ast.walk(constructor)
+                    if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+                )
+
+                # For each, check if there is something of the form super(...).__init(...)
+                def is_base_constructor_call(node):
+                    fn_call = node.func
+                    if not isinstance(fn_call.value, ast.Call):
+                        return False
+                    if not fn_call.value.func.id == "super":
+                        return False
+                    if not fn_call.attr == "__init__":
+                        return False
+
+                    return True
+
+                filtered_fn_calls = list(filter(is_base_constructor_call, fn_calls))
+
+                self.assertEqual(
+                    len(filtered_fn_calls), 1, "Call to base class constructor missing"
+                )
+
+                self.assertTrue(
+                    any(
+                        isinstance(k.value, ast.Name) and k.value.id == "kwargs"
+                        for k in filtered_fn_calls[0].keywords
+                    ),
+                    "kwargs not passed to the base class constructor",
+                )

--- a/tests/datasets/test_metadata.py
+++ b/tests/datasets/test_metadata.py
@@ -21,18 +21,19 @@ class TestDatasetMetadata(unittest.TestCase):
         "Test if all datasets export the required metadata"
 
         for dataset in self.datasets:
-            self.assertIsInstance(dataset.metadata(), dict)
-            self.assertIn("citation", dataset.metadata())
-            self.assertIsInstance(dataset.metadata()["citation"], str)
-            self.assertIn("language", dataset.metadata())
-            self.assertIsInstance(dataset.metadata()["language"], (str, list))
+            with self.subTest(msg=dataset.__name__):
+                self.assertIsInstance(dataset.metadata(), dict)
+                self.assertIn("citation", dataset.metadata())
+                self.assertIsInstance(dataset.metadata()["citation"], str)
+                self.assertIn("language", dataset.metadata())
+                self.assertIsInstance(dataset.metadata()["language"], (str, list))
 
-            languages = dataset.metadata()["language"]
-            if isinstance(languages, str):
-                languages = [languages]
+                languages = dataset.metadata()["language"]
+                if isinstance(languages, str):
+                    languages = [languages]
 
-            for language in languages:
-                self.assertTrue(
-                    language == "multilingual" or tag_is_valid(language),
-                    f"{language} is not a valid language",
-                )
+                for language in languages:
+                    self.assertTrue(
+                        language == "multilingual" or tag_is_valid(language),
+                        f"{language} is not a valid language",
+                    )

--- a/tests/models/test_exports.py
+++ b/tests/models/test_exports.py
@@ -9,7 +9,7 @@ from llmebench import utils
 from llmebench.models.model_base import ModelBase
 
 
-class TestDatasetExports(unittest.TestCase):
+class TestModelExports(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # Search for all implemented models

--- a/tests/models/test_implementation.py
+++ b/tests/models/test_implementation.py
@@ -1,10 +1,11 @@
-import ast
 import inspect
 import unittest
 
 from pathlib import Path
 
 import llmebench.models as models
+
+from tests.utils import base_class_constructor_checker
 
 
 class TestModelImplementation(unittest.TestCase):
@@ -19,51 +20,4 @@ class TestModelImplementation(unittest.TestCase):
 
         for model in self.models:
             with self.subTest(msg=model.__name__):
-                tree = ast.parse(inspect.getsource(model))
-                constructors = list(
-                    n
-                    for n in ast.walk(tree)
-                    if isinstance(n, ast.FunctionDef) and n.name == "__init__"
-                )
-                self.assertLessEqual(
-                    len(constructors), 1, "Multiple constructors found"
-                )
-
-                if len(constructors) == 0:
-                    # No constructor, base will be called by default
-                    continue
-
-                constructor = constructors[0]
-
-                # Collect all function calls inside the constructor
-                fn_calls = list(
-                    n
-                    for n in ast.walk(constructor)
-                    if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
-                )
-
-                # For each, check if there is something of the form super(...).__init(...)
-                def is_base_constructor_call(node):
-                    fn_call = node.func
-                    if not isinstance(fn_call.value, ast.Call):
-                        return False
-                    if not fn_call.value.func.id == "super":
-                        return False
-                    if not fn_call.attr == "__init__":
-                        return False
-
-                    return True
-
-                filtered_fn_calls = list(filter(is_base_constructor_call, fn_calls))
-
-                self.assertEqual(
-                    len(filtered_fn_calls), 1, "Call to base class constructor missing"
-                )
-
-                self.assertTrue(
-                    any(
-                        isinstance(k.value, ast.Name) and k.value.id == "kwargs"
-                        for k in filtered_fn_calls[0].keywords
-                    ),
-                    "kwargs not passed to the base class constructor",
-                )
+                base_class_constructor_checker(model, self)

--- a/tests/models/test_implementation.py
+++ b/tests/models/test_implementation.py
@@ -1,0 +1,69 @@
+import ast
+import inspect
+import unittest
+
+from pathlib import Path
+
+import llmebench.models as models
+
+
+class TestModelImplementation(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Search for all implemented models
+        framework_dir = Path("llmebench")
+        cls.models = set([m[1] for m in inspect.getmembers(models, inspect.isclass)])
+
+    def test_base_constructor(self):
+        "Test if all models also call the base class constructor"
+
+        for model in self.models:
+            with self.subTest(msg=model.__name__):
+                tree = ast.parse(inspect.getsource(model))
+                constructors = list(
+                    n
+                    for n in ast.walk(tree)
+                    if isinstance(n, ast.FunctionDef) and n.name == "__init__"
+                )
+                self.assertLessEqual(
+                    len(constructors), 1, "Multiple constructors found"
+                )
+
+                if len(constructors) == 0:
+                    # No constructor, base will be called by default
+                    continue
+
+                constructor = constructors[0]
+
+                # Collect all function calls inside the constructor
+                fn_calls = list(
+                    n
+                    for n in ast.walk(constructor)
+                    if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+                )
+
+                # For each, check if there is something of the form super(...).__init(...)
+                def is_base_constructor_call(node):
+                    fn_call = node.func
+                    if not isinstance(fn_call.value, ast.Call):
+                        return False
+                    if not fn_call.value.func.id == "super":
+                        return False
+                    if not fn_call.attr == "__init__":
+                        return False
+
+                    return True
+
+                filtered_fn_calls = list(filter(is_base_constructor_call, fn_calls))
+
+                self.assertEqual(
+                    len(filtered_fn_calls), 1, "Call to base class constructor missing"
+                )
+
+                self.assertTrue(
+                    any(
+                        isinstance(k.value, ast.Name) and k.value.id == "kwargs"
+                        for k in filtered_fn_calls[0].keywords
+                    ),
+                    "kwargs not passed to the base class constructor",
+                )

--- a/tests/tasks/test_implementation.py
+++ b/tests/tasks/test_implementation.py
@@ -1,0 +1,69 @@
+import ast
+import inspect
+import unittest
+
+from pathlib import Path
+
+import llmebench.tasks as tasks
+
+
+class TestTaskImplementation(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Search for all implemented models
+        framework_dir = Path("llmebench")
+        cls.tasks = set([m[1] for m in inspect.getmembers(tasks, inspect.isclass)])
+
+    def test_base_constructor(self):
+        "Test if all tasks also call the base class constructor"
+
+        for task in self.tasks:
+            with self.subTest(msg=task.__name__):
+                tree = ast.parse(inspect.getsource(task))
+                constructors = list(
+                    n
+                    for n in ast.walk(tree)
+                    if isinstance(n, ast.FunctionDef) and n.name == "__init__"
+                )
+                self.assertLessEqual(
+                    len(constructors), 1, "Multiple constructors found"
+                )
+
+                if len(constructors) == 0:
+                    # No constructor, base will be called by default
+                    continue
+
+                constructor = constructors[0]
+
+                # Collect all function calls inside the constructor
+                fn_calls = list(
+                    n
+                    for n in ast.walk(constructor)
+                    if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+                )
+
+                # For each, check if there is something of the form super(...).__init(...)
+                def is_base_constructor_call(node):
+                    fn_call = node.func
+                    if not isinstance(fn_call.value, ast.Call):
+                        return False
+                    if not fn_call.value.func.id == "super":
+                        return False
+                    if not fn_call.attr == "__init__":
+                        return False
+
+                    return True
+
+                filtered_fn_calls = list(filter(is_base_constructor_call, fn_calls))
+
+                self.assertEqual(
+                    len(filtered_fn_calls), 1, "Call to base class constructor missing"
+                )
+
+                self.assertTrue(
+                    any(
+                        isinstance(k.value, ast.Name) and k.value.id == "kwargs"
+                        for k in filtered_fn_calls[0].keywords
+                    ),
+                    "kwargs not passed to the base class constructor",
+                )

--- a/tests/tasks/test_implementation.py
+++ b/tests/tasks/test_implementation.py
@@ -1,10 +1,11 @@
-import ast
 import inspect
 import unittest
 
 from pathlib import Path
 
 import llmebench.tasks as tasks
+
+from tests.utils import base_class_constructor_checker
 
 
 class TestTaskImplementation(unittest.TestCase):
@@ -19,51 +20,4 @@ class TestTaskImplementation(unittest.TestCase):
 
         for task in self.tasks:
             with self.subTest(msg=task.__name__):
-                tree = ast.parse(inspect.getsource(task))
-                constructors = list(
-                    n
-                    for n in ast.walk(tree)
-                    if isinstance(n, ast.FunctionDef) and n.name == "__init__"
-                )
-                self.assertLessEqual(
-                    len(constructors), 1, "Multiple constructors found"
-                )
-
-                if len(constructors) == 0:
-                    # No constructor, base will be called by default
-                    continue
-
-                constructor = constructors[0]
-
-                # Collect all function calls inside the constructor
-                fn_calls = list(
-                    n
-                    for n in ast.walk(constructor)
-                    if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
-                )
-
-                # For each, check if there is something of the form super(...).__init(...)
-                def is_base_constructor_call(node):
-                    fn_call = node.func
-                    if not isinstance(fn_call.value, ast.Call):
-                        return False
-                    if not fn_call.value.func.id == "super":
-                        return False
-                    if not fn_call.attr == "__init__":
-                        return False
-
-                    return True
-
-                filtered_fn_calls = list(filter(is_base_constructor_call, fn_calls))
-
-                self.assertEqual(
-                    len(filtered_fn_calls), 1, "Call to base class constructor missing"
-                )
-
-                self.assertTrue(
-                    any(
-                        isinstance(k.value, ast.Name) and k.value.id == "kwargs"
-                        for k in filtered_fn_calls[0].keywords
-                    ),
-                    "kwargs not passed to the base class constructor",
-                )
+                base_class_constructor_checker(task, self)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,51 @@
+import ast
+import inspect
+
+
+def base_class_constructor_checker(class_implementation, tester):
+    tree = ast.parse(inspect.getsource(class_implementation))
+    constructors = list(
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.FunctionDef) and n.name == "__init__"
+    )
+    tester.assertLessEqual(len(constructors), 1, "Multiple constructors found")
+
+    if len(constructors) == 0:
+        # No constructor, base will be called by default
+        return
+
+    constructor = constructors[0]
+
+    # Collect all function calls inside the constructor
+    fn_calls = list(
+        n
+        for n in ast.walk(constructor)
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+    )
+
+    # For each, check if there is something of the form super(...).__init(...)
+    def is_base_constructor_call(node):
+        fn_call = node.func
+        if not isinstance(fn_call.value, ast.Call):
+            return False
+        if not fn_call.value.func.id == "super":
+            return False
+        if not fn_call.attr == "__init__":
+            return False
+
+        return True
+
+    filtered_fn_calls = list(filter(is_base_constructor_call, fn_calls))
+
+    tester.assertEqual(
+        len(filtered_fn_calls), 1, "Call to base class constructor missing"
+    )
+
+    tester.assertTrue(
+        any(
+            isinstance(k.value, ast.Name) and k.value.id == "kwargs"
+            for k in filtered_fn_calls[0].keywords
+        ),
+        "kwargs not passed to the base class constructor",
+    )


### PR DESCRIPTION
This commit adds tests that ensure the base class constructor is called when creating any dataset/model/task object, and that it is called with the correct arguments. Also includes minor fixes to existing tests.