### PR TITLE
Update asset configs to remove empty optional arguments

### DIFF
--- a/assets/ar/MT/AraBench_Ara2Eng_Helsinki_NLP_Opus_MT_ZeroShot.py
+++ b/assets/ar/MT/AraBench_Ara2Eng_Helsinki_NLP_Opus_MT_ZeroShot.py
@@ -19,7 +19,6 @@ def config():
             "tgt_lang": "en",
         },
         "task": MachineTranslationTask,
-        "task_args": {},
         "model": HuggingFaceInferenceAPIModel,
         "model_args": {
             "task_type": HuggingFaceTaskTypes.Translation,

--- a/assets/ar/MT/AraBench_ar2en_BLOOMZ_ZeroShot.py
+++ b/assets/ar/MT/AraBench_ar2en_BLOOMZ_ZeroShot.py
@@ -19,7 +19,6 @@ def config():
             "tgt_lang": "en",
         },
         "task": MachineTranslationTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/MT/AraBench_ar2en_GPT35_ZeroShot.py
+++ b/assets/ar/MT/AraBench_ar2en_GPT35_ZeroShot.py
@@ -19,7 +19,6 @@ def config():
             "tgt_lang": "en",
         },
         "task": MachineTranslationTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "max_tries": 5,

--- a/assets/ar/MT/AraBench_ar2en_GPT4_ZeroShot.py
+++ b/assets/ar/MT/AraBench_ar2en_GPT4_ZeroShot.py
@@ -19,7 +19,6 @@ def config():
             "tgt_lang": "en",
         },
         "task": MachineTranslationTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 5,

--- a/assets/ar/QA/ARCD_BLOOMZ_ZeroShot.py
+++ b/assets/ar/QA/ARCD_BLOOMZ_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ARCDDataset,
-        "dataset_args": {},
         "task": QATask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "max_tries": 5,

--- a/assets/ar/QA/ARCD_GPT35_ZeroShot.py
+++ b/assets/ar/QA/ARCD_GPT35_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ARCDDataset,
-        "dataset_args": {},
         "task": QATask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/QA/ARCD_GPT4_FewShot.py
+++ b/assets/ar/QA/ARCD_GPT4_FewShot.py
@@ -19,9 +19,7 @@ def metadata():
 def config():
     return {
         "dataset": ARCDDataset,
-        "dataset_args": {},
         "task": QATask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 30,

--- a/assets/ar/QA/ARCD_GPT4_ZeroShot.py
+++ b/assets/ar/QA/ARCD_GPT4_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ARCDDataset,
-        "dataset_args": {},
         "task": QATask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 50,

--- a/assets/ar/QA/ARCD_Random.py
+++ b/assets/ar/QA/ARCD_Random.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": ARCDDataset,
-        "dataset_args": {},
         "task": QATask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {"task_type": TaskType.QuestionAnswering},
         "general_args": {},

--- a/assets/ar/QA/MLQA_BLOOMZ_ZeroShot.py
+++ b/assets/ar/QA/MLQA_BLOOMZ_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": MLQADataset,
-        "dataset_args": {},
         "task": QATask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "max_tries": 5,

--- a/assets/ar/QA/MLQA_GPT35_ZeroShot.py
+++ b/assets/ar/QA/MLQA_GPT35_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": MLQADataset,
-        "dataset_args": {},
         "task": QATask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/QA/MLQA_GPT4_FewShot.py
+++ b/assets/ar/QA/MLQA_GPT4_FewShot.py
@@ -19,9 +19,7 @@ def metadata():
 def config():
     return {
         "dataset": MLQADataset,
-        "dataset_args": {},
         "task": QATask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 30,

--- a/assets/ar/QA/MLQA_GPT4_ZeroShot.py
+++ b/assets/ar/QA/MLQA_GPT4_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": MLQADataset,
-        "dataset_args": {},
         "task": QATask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 50,

--- a/assets/ar/QA/MLQA_Random.py
+++ b/assets/ar/QA/MLQA_Random.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": MLQADataset,
-        "dataset_args": {},
         "task": QATask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {"task_type": TaskType.QuestionAnswering},
         "general_args": {},

--- a/assets/ar/QA/MLQA_mdeberta_v3_base_squad2_ZeroShot.py
+++ b/assets/ar/QA/MLQA_mdeberta_v3_base_squad2_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": MLQADataset,
-        "dataset_args": {},
         "task": QATask,
-        "task_args": {},
         "model": HuggingFaceInferenceAPIModel,
         "model_args": {
             "task_type": HuggingFaceTaskTypes.Question_Answering,

--- a/assets/ar/QA/TyDiQA_BLOOMZ_ZeroShot.py
+++ b/assets/ar/QA/TyDiQA_BLOOMZ_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": TyDiQADataset,
-        "dataset_args": {},
         "task": QATask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "max_tries": 5,

--- a/assets/ar/QA/TyDiQA_GPT35_ZeroShot.py
+++ b/assets/ar/QA/TyDiQA_GPT35_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": TyDiQADataset,
-        "dataset_args": {},
         "task": QATask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/QA/TyDiQA_GPT4_FewShot.py
+++ b/assets/ar/QA/TyDiQA_GPT4_FewShot.py
@@ -19,9 +19,7 @@ def metadata():
 def config():
     return {
         "dataset": TyDiQADataset,
-        "dataset_args": {},
         "task": QATask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 30,

--- a/assets/ar/QA/TyDiQA_GPT4_ZeroShot.py
+++ b/assets/ar/QA/TyDiQA_GPT4_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": TyDiQADataset,
-        "dataset_args": {},
         "task": QATask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 50,

--- a/assets/ar/QA/TyDiQA_Random.py
+++ b/assets/ar/QA/TyDiQA_Random.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": TyDiQADataset,
-        "dataset_args": {},
         "task": QATask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {"task_type": TaskType.QuestionAnswering},
         "general_args": {"test_split": "dev"},

--- a/assets/ar/QA/XQuAD_BLOOMZ_ZeroShot.py
+++ b/assets/ar/QA/XQuAD_BLOOMZ_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": XQuADDataset,
-        "dataset_args": {},
         "task": QATask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "max_tries": 5,

--- a/assets/ar/QA/XQuAD_GPT35_ZeroShot.py
+++ b/assets/ar/QA/XQuAD_GPT35_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": XQuADDataset,
-        "dataset_args": {},
         "task": QATask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/QA/XQuAD_GPT4_FewShot.py
+++ b/assets/ar/QA/XQuAD_GPT4_FewShot.py
@@ -19,9 +19,7 @@ def metadata():
 def config():
     return {
         "dataset": XQuADDataset,
-        "dataset_args": {},
         "task": QATask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 30,

--- a/assets/ar/QA/XQuAD_GPT4_ZeroShot.py
+++ b/assets/ar/QA/XQuAD_GPT4_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": XQuADDataset,
-        "dataset_args": {},
         "task": QATask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 50,

--- a/assets/ar/QA/XQuAD_Random.py
+++ b/assets/ar/QA/XQuAD_Random.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": XQuADDataset,
-        "dataset_args": {},
         "task": QATask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {"task_type": TaskType.QuestionAnswering},
         "general_args": {},

--- a/assets/ar/demographic_attributes/gender/ArabGend_BLOOMZ_ZeroShot.py
+++ b/assets/ar/demographic_attributes/gender/ArabGend_BLOOMZ_ZeroShot.py
@@ -14,9 +14,7 @@ def metadata():
 def config():
     return {
         "dataset": ArabGendDataset,
-        "dataset_args": {},
         "task": DemographyGenderTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": ["m", "f"],

--- a/assets/ar/demographic_attributes/gender/ArabGend_GPT35_ZeroShot.py
+++ b/assets/ar/demographic_attributes/gender/ArabGend_GPT35_ZeroShot.py
@@ -14,9 +14,7 @@ def metadata():
 def config():
     return {
         "dataset": ArabGendDataset,
-        "dataset_args": {},
         "task": DemographyGenderTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "class_labels": ["m", "f"],

--- a/assets/ar/demographic_attributes/gender/ArabGend_GPT4_ZeroShot.py
+++ b/assets/ar/demographic_attributes/gender/ArabGend_GPT4_ZeroShot.py
@@ -14,9 +14,7 @@ def metadata():
 def config():
     return {
         "dataset": ArabGendDataset,
-        "dataset_args": {},
         "task": DemographyGenderTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["m", "f"],

--- a/assets/ar/demographic_attributes/gender/ArabGend_Random.py
+++ b/assets/ar/demographic_attributes/gender/ArabGend_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ArabGendDataset,
-        "dataset_args": {},
         "task": DemographyGenderTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/assets/ar/demographic_attributes/gender/ArapTweet_BLOOMZ_ZeroShot.py
+++ b/assets/ar/demographic_attributes/gender/ArapTweet_BLOOMZ_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ArapTweetDataset,
-        "dataset_args": {},
         "task": DemographyGenderTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": ["Female", "Male"],

--- a/assets/ar/demographic_attributes/gender/ArapTweet_GPT35_ZeroShot.py
+++ b/assets/ar/demographic_attributes/gender/ArapTweet_GPT35_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ArapTweetDataset,
-        "dataset_args": {},
         "task": DemographyGenderTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "class_labels": ["Female", "Male"],

--- a/assets/ar/demographic_attributes/gender/ArapTweet_GPT4_FewShot.py
+++ b/assets/ar/demographic_attributes/gender/ArapTweet_GPT4_FewShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ArapTweetDataset,
-        "dataset_args": {},
         "task": DemographyGenderTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["Female", "Male"],

--- a/assets/ar/demographic_attributes/gender/ArapTweet_GPT4_ZeroShot.py
+++ b/assets/ar/demographic_attributes/gender/ArapTweet_GPT4_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ArapTweetDataset,
-        "dataset_args": {},
         "task": DemographyGenderTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["Female", "Male"],

--- a/assets/ar/demographic_attributes/gender/ArapTweet_Random.py
+++ b/assets/ar/demographic_attributes/gender/ArapTweet_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ArapTweetDataset,
-        "dataset_args": {},
         "task": DemographyGenderTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/assets/ar/demographic_attributes/location/Location_BLOOMZ_ZeroShot.py
+++ b/assets/ar/demographic_attributes/location/Location_BLOOMZ_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": LocationDataset,
-        "dataset_args": {},
         "task": DemographyLocationTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/demographic_attributes/location/Location_GPT35_ZeroShot.py
+++ b/assets/ar/demographic_attributes/location/Location_GPT35_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": LocationDataset,
-        "dataset_args": {},
         "task": DemographyLocationTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/demographic_attributes/location/Location_GPT4_FewShot.py
+++ b/assets/ar/demographic_attributes/location/Location_GPT4_FewShot.py
@@ -14,9 +14,7 @@ def metadata():
 def config():
     return {
         "dataset": LocationDataset,
-        "dataset_args": {},
         "task": DemographyLocationTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/demographic_attributes/location/Location_GPT4_ZeroShot.py
+++ b/assets/ar/demographic_attributes/location/Location_GPT4_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": LocationDataset,
-        "dataset_args": {},
         "task": DemographyLocationTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/demographic_attributes/location/Location_Random.py
+++ b/assets/ar/demographic_attributes/location/Location_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": LocationDataset,
-        "dataset_args": {},
         "task": DemographyLocationTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/assets/ar/demographic_attributes/name_info/NameInfo_BLOOMZ_ZeroShot.py
+++ b/assets/ar/demographic_attributes/name_info/NameInfo_BLOOMZ_ZeroShot.py
@@ -16,9 +16,7 @@ def metadata():
 def config():
     return {
         "dataset": NameInfoDataset,
-        "dataset_args": {},
         "task": DemographyNameInfoTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/demographic_attributes/name_info/NameInfo_GPT35_ZeroShot.py
+++ b/assets/ar/demographic_attributes/name_info/NameInfo_GPT35_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": NameInfoDataset,
-        "dataset_args": {},
         "task": DemographyNameInfoTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/demographic_attributes/name_info/NameInfo_GPT4_FewShot.py
+++ b/assets/ar/demographic_attributes/name_info/NameInfo_GPT4_FewShot.py
@@ -14,9 +14,7 @@ def metadata():
 def config():
     return {
         "dataset": NameInfoDataset,
-        "dataset_args": {},
         "task": DemographyNameInfoTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/demographic_attributes/name_info/NameInfo_GPT4_ZeroShot.py
+++ b/assets/ar/demographic_attributes/name_info/NameInfo_GPT4_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": NameInfoDataset,
-        "dataset_args": {},
         "task": DemographyNameInfoTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/demographic_attributes/name_info/NameInfo_Random.py
+++ b/assets/ar/demographic_attributes/name_info/NameInfo_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": NameInfoDataset,
-        "dataset_args": {},
         "task": DemographyNameInfoTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/assets/ar/factuality_disinformation_harmful_content/adult_content_detection/Adult_BLOOMZ_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/adult_content_detection/Adult_BLOOMZ_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": AdultDataset,
-        "dataset_args": {},
         "task": AdultTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": ["ADULT", "NOT_ADULT"],

--- a/assets/ar/factuality_disinformation_harmful_content/adult_content_detection/Adult_GPT35_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/adult_content_detection/Adult_GPT35_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": AdultDataset,
-        "dataset_args": {},
         "task": AdultTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "class_labels": ["ADULT", "NOT_ADULT"],

--- a/assets/ar/factuality_disinformation_harmful_content/adult_content_detection/Adult_GPT4_FewShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/adult_content_detection/Adult_GPT4_FewShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": AdultDataset,
-        "dataset_args": {},
         "task": AdultTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["ADULT", "NOT_ADULT"],

--- a/assets/ar/factuality_disinformation_harmful_content/adult_content_detection/Adult_GPT4_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/adult_content_detection/Adult_GPT4_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": AdultDataset,
-        "dataset_args": {},
         "task": AdultTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["ADULT", "NOT_ADULT"],

--- a/assets/ar/factuality_disinformation_harmful_content/adult_content_detection/Adult_Random.py
+++ b/assets/ar/factuality_disinformation_harmful_content/adult_content_detection/Adult_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": AdultDataset,
-        "dataset_args": {},
         "task": AdultTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/assets/ar/factuality_disinformation_harmful_content/attentionworthy/CT22Attentionworthy_BLOOMZ_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/attentionworthy/CT22Attentionworthy_BLOOMZ_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22AttentionworthyDataset,
-        "dataset_args": {},
         "task": AttentionworthyTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/factuality_disinformation_harmful_content/attentionworthy/CT22Attentionworthy_GPT35_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/attentionworthy/CT22Attentionworthy_GPT35_ZeroShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22AttentionworthyDataset,
-        "dataset_args": {},
         "task": AttentionworthyTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/factuality_disinformation_harmful_content/attentionworthy/CT22Attentionworthy_GPT4_FewShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/attentionworthy/CT22Attentionworthy_GPT4_FewShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22AttentionworthyDataset,
-        "dataset_args": {},
         "task": AttentionworthyTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/factuality_disinformation_harmful_content/attentionworthy/CT22Attentionworthy_GPT4_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/attentionworthy/CT22Attentionworthy_GPT4_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22AttentionworthyDataset,
-        "dataset_args": {},
         "task": AttentionworthyTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/factuality_disinformation_harmful_content/attentionworthy/CT22Attentionworthy_Random.py
+++ b/assets/ar/factuality_disinformation_harmful_content/attentionworthy/CT22Attentionworthy_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22AttentionworthyDataset,
-        "dataset_args": {},
         "task": AttentionworthyTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/assets/ar/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_BLOOMZ_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_BLOOMZ_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22CheckworthinessDataset,
-        "dataset_args": {},
         "task": CheckworthinessTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": ["0", "1"],

--- a/assets/ar/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_GPT35_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_GPT35_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22CheckworthinessDataset,
-        "dataset_args": {},
         "task": CheckworthinessTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "class_labels": ["0", "1"],

--- a/assets/ar/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_GPT4_FewShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_GPT4_FewShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22CheckworthinessDataset,
-        "dataset_args": {},
         "task": CheckworthinessTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["0", "1"],

--- a/assets/ar/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_GPT4_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_GPT4_ZeroShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22CheckworthinessDataset,
-        "dataset_args": {},
         "task": CheckworthinessTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["0", "1"],

--- a/assets/ar/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_Random.py
+++ b/assets/ar/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22CheckworthinessDataset,
-        "dataset_args": {},
         "task": CheckworthinessTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/assets/ar/factuality_disinformation_harmful_content/claim_detection/CT22Claim_BLOOMZ_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/claim_detection/CT22Claim_BLOOMZ_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22ClaimDataset,
-        "dataset_args": {},
         "task": ClaimDetectionTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/factuality_disinformation_harmful_content/claim_detection/CT22Claim_GPT35_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/claim_detection/CT22Claim_GPT35_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22ClaimDataset,
-        "dataset_args": {},
         "task": ClaimDetectionTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "class_labels": ["0", "1"],

--- a/assets/ar/factuality_disinformation_harmful_content/claim_detection/CT22Claim_GPT4_FewShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/claim_detection/CT22Claim_GPT4_FewShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22ClaimDataset,
-        "dataset_args": {},
         "task": ClaimDetectionTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/factuality_disinformation_harmful_content/claim_detection/CT22Claim_GPT4_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/claim_detection/CT22Claim_GPT4_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22ClaimDataset,
-        "dataset_args": {},
         "task": ClaimDetectionTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["0", "1"],

--- a/assets/ar/factuality_disinformation_harmful_content/claim_detection/CT22Claim_Random.py
+++ b/assets/ar/factuality_disinformation_harmful_content/claim_detection/CT22Claim_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22ClaimDataset,
-        "dataset_args": {},
         "task": ClaimDetectionTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/assets/ar/factuality_disinformation_harmful_content/factuality/ANSFactuality_BLOOMZ_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/factuality/ANSFactuality_BLOOMZ_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ANSFactualityDataset,
-        "dataset_args": {},
         "task": FactualityTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": ["true", "false"],

--- a/assets/ar/factuality_disinformation_harmful_content/factuality/ANSFactuality_GPT35_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/factuality/ANSFactuality_GPT35_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ANSFactualityDataset,
-        "dataset_args": {},
         "task": FactualityTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "class_labels": ["true", "false"],

--- a/assets/ar/factuality_disinformation_harmful_content/factuality/ANSFactuality_GPT4_FewShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/factuality/ANSFactuality_GPT4_FewShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ANSFactualityDataset,
-        "dataset_args": {},
         "task": FactualityTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/factuality_disinformation_harmful_content/factuality/ANSFactuality_GPT4_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/factuality/ANSFactuality_GPT4_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ANSFactualityDataset,
-        "dataset_args": {},
         "task": FactualityTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/factuality_disinformation_harmful_content/factuality/ANSFactuality_Random.py
+++ b/assets/ar/factuality_disinformation_harmful_content/factuality/ANSFactuality_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ANSFactualityDataset,
-        "dataset_args": {},
         "task": FactualityTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/assets/ar/factuality_disinformation_harmful_content/factuality/COVID19Factuality_BLOOMZ_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/factuality/COVID19Factuality_BLOOMZ_ZeroShot.py
@@ -14,9 +14,7 @@ def metadata():
 def config():
     return {
         "dataset": COVID19FactualityDataset,
-        "dataset_args": {},
         "task": FactualityTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": ["yes", "no"],

--- a/assets/ar/factuality_disinformation_harmful_content/factuality/COVID19Factuality_GPT35_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/factuality/COVID19Factuality_GPT35_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": COVID19FactualityDataset,
-        "dataset_args": {},
         "task": FactualityTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "class_labels": ["yes", "no"],

--- a/assets/ar/factuality_disinformation_harmful_content/factuality/COVID19Factuality_GPT4_FewShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/factuality/COVID19Factuality_GPT4_FewShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": COVID19FactualityDataset,
-        "dataset_args": {},
         "task": FactualityTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["yes", "no"],

--- a/assets/ar/factuality_disinformation_harmful_content/factuality/COVID19Factuality_GPT4_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/factuality/COVID19Factuality_GPT4_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": COVID19FactualityDataset,
-        "dataset_args": {},
         "task": FactualityTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["yes", "no"],

--- a/assets/ar/factuality_disinformation_harmful_content/factuality/COVID19Factuality_Random.py
+++ b/assets/ar/factuality_disinformation_harmful_content/factuality/COVID19Factuality_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": COVID19FactualityDataset,
-        "dataset_args": {},
         "task": FactualityTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/assets/ar/factuality_disinformation_harmful_content/factuality/UnifiedFCFactuality_BLOOMZ_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/factuality/UnifiedFCFactuality_BLOOMZ_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": UnifiedFCFactualityDataset,
-        "dataset_args": {},
         "task": FactualityTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": ["true", "false"],

--- a/assets/ar/factuality_disinformation_harmful_content/factuality/UnifiedFCFactuality_GPT35_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/factuality/UnifiedFCFactuality_GPT35_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": UnifiedFCFactualityDataset,
-        "dataset_args": {},
         "task": FactualityTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "class_labels": ["true", "false"],

--- a/assets/ar/factuality_disinformation_harmful_content/factuality/UnifiedFCFactuality_GPT4_FewShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/factuality/UnifiedFCFactuality_GPT4_FewShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": UnifiedFCFactualityDataset,
-        "dataset_args": {},
         "task": FactualityTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/factuality_disinformation_harmful_content/factuality/UnifiedFCFactuality_GPT4_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/factuality/UnifiedFCFactuality_GPT4_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": UnifiedFCFactualityDataset,
-        "dataset_args": {},
         "task": FactualityTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["true", "false"],

--- a/assets/ar/factuality_disinformation_harmful_content/factuality/UnifiedFCFactuality_Random.py
+++ b/assets/ar/factuality_disinformation_harmful_content/factuality/UnifiedFCFactuality_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": UnifiedFCFactualityDataset,
-        "dataset_args": {},
         "task": FactualityTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/assets/ar/factuality_disinformation_harmful_content/harmfulness_detection/CT22Harmful_BLOOMZ_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/harmfulness_detection/CT22Harmful_BLOOMZ_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22HarmfulDataset,
-        "dataset_args": {},
         "task": HarmfulDetectionTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/factuality_disinformation_harmful_content/harmfulness_detection/CT22Harmful_GPT35_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/harmfulness_detection/CT22Harmful_GPT35_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22HarmfulDataset,
-        "dataset_args": {},
         "task": HarmfulDetectionTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "class_labels": ["0", "1"],

--- a/assets/ar/factuality_disinformation_harmful_content/harmfulness_detection/CT22Harmful_GPT4_FewShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/harmfulness_detection/CT22Harmful_GPT4_FewShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22HarmfulDataset,
-        "dataset_args": {},
         "task": HarmfulDetectionTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/factuality_disinformation_harmful_content/harmfulness_detection/CT22Harmful_GPT4_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/harmfulness_detection/CT22Harmful_GPT4_ZeroShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22HarmfulDataset,
-        "dataset_args": {},
         "task": HarmfulDetectionTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["0", "1"],

--- a/assets/ar/factuality_disinformation_harmful_content/harmfulness_detection/CT22Harmful_Random.py
+++ b/assets/ar/factuality_disinformation_harmful_content/harmfulness_detection/CT22Harmful_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22HarmfulDataset,
-        "dataset_args": {},
         "task": HarmfulDetectionTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/assets/ar/factuality_disinformation_harmful_content/hate_speech/OSACT4SubtaskB_BLOOMZ_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/hate_speech/OSACT4SubtaskB_BLOOMZ_ZeroShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": OSACT4SubtaskBDataset,
-        "dataset_args": {},
         "task": HateSpeechTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": ["HS", "NOT_HS"],

--- a/assets/ar/factuality_disinformation_harmful_content/hate_speech/OSACT4SubtaskB_GPT35_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/hate_speech/OSACT4SubtaskB_GPT35_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": OSACT4SubtaskBDataset,
-        "dataset_args": {},
         "task": HateSpeechTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "class_labels": ["HS", "NOT_HS"],

--- a/assets/ar/factuality_disinformation_harmful_content/hate_speech/OSACT4SubtaskB_GPT4_FewShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/hate_speech/OSACT4SubtaskB_GPT4_FewShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": OSACT4SubtaskBDataset,
-        "dataset_args": {},
         "task": HateSpeechTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/factuality_disinformation_harmful_content/hate_speech/OSACT4SubtaskB_GPT4_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/hate_speech/OSACT4SubtaskB_GPT4_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": OSACT4SubtaskBDataset,
-        "dataset_args": {},
         "task": HateSpeechTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["HS", "NOT_HS"],

--- a/assets/ar/factuality_disinformation_harmful_content/hate_speech/OSACT4SubtaskB_Random.py
+++ b/assets/ar/factuality_disinformation_harmful_content/hate_speech/OSACT4SubtaskB_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": OSACT4SubtaskBDataset,
-        "dataset_args": {},
         "task": HateSpeechTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/assets/ar/factuality_disinformation_harmful_content/offensive_language/OSACT4SubtaskA_BLOOMZ_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/offensive_language/OSACT4SubtaskA_BLOOMZ_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": OSACT4SubtaskADataset,
-        "dataset_args": {},
         "task": OffensiveTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": ["OFF", "NOT_OFF"],

--- a/assets/ar/factuality_disinformation_harmful_content/offensive_language/OSACT4SubtaskA_GPT35_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/offensive_language/OSACT4SubtaskA_GPT35_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": OSACT4SubtaskADataset,
-        "dataset_args": {},
         "task": OffensiveTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "class_labels": ["OFF", "NOT_OFF"],

--- a/assets/ar/factuality_disinformation_harmful_content/offensive_language/OSACT4SubtaskA_GPT4_FewShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/offensive_language/OSACT4SubtaskA_GPT4_FewShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": OSACT4SubtaskADataset,
-        "dataset_args": {},
         "task": OffensiveTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["OFF", "NOT_OFF"],

--- a/assets/ar/factuality_disinformation_harmful_content/offensive_language/OSACT4SubtaskA_GPT4_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/offensive_language/OSACT4SubtaskA_GPT4_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": OSACT4SubtaskADataset,
-        "dataset_args": {},
         "task": OffensiveTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["OFF", "NOT_OFF"],

--- a/assets/ar/factuality_disinformation_harmful_content/offensive_language/OSACT4SubtaskA_Random.py
+++ b/assets/ar/factuality_disinformation_harmful_content/offensive_language/OSACT4SubtaskA_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": OSACT4SubtaskADataset,
-        "dataset_args": {},
         "task": OffensiveTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/assets/ar/factuality_disinformation_harmful_content/propaganda/WANLP22T3_BLOOMZ_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/propaganda/WANLP22T3_BLOOMZ_ZeroShot.py
@@ -23,7 +23,6 @@ def config():
         "dataset": WANLP22T3PropagandaDataset,
         "dataset_args": {"techniques_path": "classes.txt"},
         "task": MultilabelPropagandaTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/factuality_disinformation_harmful_content/propaganda/WANLP22T3_GPT35_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/propaganda/WANLP22T3_GPT35_ZeroShot.py
@@ -19,7 +19,6 @@ def config():
         "dataset": WANLP22T3PropagandaDataset,
         "dataset_args": {"techniques_path": "classes.txt"},
         "task": MultilabelPropagandaTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/factuality_disinformation_harmful_content/propaganda/WANLP22T3_GPT4_FewShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/propaganda/WANLP22T3_GPT4_FewShot.py
@@ -23,7 +23,6 @@ def config():
         "dataset": WANLP22T3PropagandaDataset,
         "dataset_args": {"techniques_path": "classes.txt"},
         "task": MultilabelPropagandaTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/factuality_disinformation_harmful_content/propaganda/WANLP22T3_GPT4_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/propaganda/WANLP22T3_GPT4_ZeroShot.py
@@ -23,7 +23,6 @@ def config():
         "dataset": WANLP22T3PropagandaDataset,
         "dataset_args": {"techniques_path": "classes.txt"},
         "task": MultilabelPropagandaTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/factuality_disinformation_harmful_content/propaganda/WANLP22T3_Random.py
+++ b/assets/ar/factuality_disinformation_harmful_content/propaganda/WANLP22T3_Random.py
@@ -17,7 +17,6 @@ def config():
         "dataset": WANLP22T3PropagandaDataset,
         "dataset_args": {"techniques_path": "classes.txt"},
         "task": MultilabelPropagandaTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.MultiLabelClassification,

--- a/assets/ar/factuality_disinformation_harmful_content/spam/Spam_BLOOMZ_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/spam/Spam_BLOOMZ_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": SpamDataset,
-        "dataset_args": {},
         "task": SpamTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": ["__label__ADS", "__label__NOTADS"],

--- a/assets/ar/factuality_disinformation_harmful_content/spam/Spam_GPT35_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/spam/Spam_GPT35_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": SpamDataset,
-        "dataset_args": {},
         "task": SpamTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "class_labels": ["__label__ADS", "__label__NOTADS"],

--- a/assets/ar/factuality_disinformation_harmful_content/spam/Spam_GPT4_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/spam/Spam_GPT4_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": SpamDataset,
-        "dataset_args": {},
         "task": SpamTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["__label__ADS", "__label__NOTADS"],

--- a/assets/ar/factuality_disinformation_harmful_content/spam/Spam_Random.py
+++ b/assets/ar/factuality_disinformation_harmful_content/spam/Spam_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": SpamDataset,
-        "dataset_args": {},
         "task": SpamTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/assets/ar/factuality_disinformation_harmful_content/subjectivity/CT23Subjectivity_BLOOMZ_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/subjectivity/CT23Subjectivity_BLOOMZ_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": CT23SubjectivityDataset,
-        "dataset_args": {},
         "task": SubjectivityTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": ["SUBJ", "OBJ"],

--- a/assets/ar/factuality_disinformation_harmful_content/subjectivity/CT23Subjectivity_GPT35_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/subjectivity/CT23Subjectivity_GPT35_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": CT23SubjectivityDataset,
-        "dataset_args": {},
         "task": SubjectivityTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "class_labels": ["SUBJ", "OBJ"],

--- a/assets/ar/factuality_disinformation_harmful_content/subjectivity/CT23Subjectivity_GPT4_FewShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/subjectivity/CT23Subjectivity_GPT4_FewShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": CT23SubjectivityDataset,
-        "dataset_args": {},
         "task": SubjectivityTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["SUBJ", "OBJ"],

--- a/assets/ar/factuality_disinformation_harmful_content/subjectivity/CT23Subjectivity_GPT4_ZeroShot.py
+++ b/assets/ar/factuality_disinformation_harmful_content/subjectivity/CT23Subjectivity_GPT4_ZeroShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": CT23SubjectivityDataset,
-        "dataset_args": {},
         "task": SubjectivityTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["SUBJ", "OBJ"],

--- a/assets/ar/factuality_disinformation_harmful_content/subjectivity/CT23Subjectivity_Random.py
+++ b/assets/ar/factuality_disinformation_harmful_content/subjectivity/CT23Subjectivity_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": CT23SubjectivityDataset,
-        "dataset_args": {},
         "task": SubjectivityTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/assets/ar/news_categorization/ASND_BLOOMZ_ZeroShot.py
+++ b/assets/ar/news_categorization/ASND_BLOOMZ_ZeroShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": ASNDDataset,
-        "dataset_args": {},
         "task": NewsCategorizationTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/news_categorization/ASND_GPT35_ZeroShot.py
+++ b/assets/ar/news_categorization/ASND_GPT35_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ASNDDataset,
-        "dataset_args": {},
         "task": NewsCategorizationTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/news_categorization/ASND_GPT4_FewShot.py
+++ b/assets/ar/news_categorization/ASND_GPT4_FewShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ASNDDataset,
-        "dataset_args": {},
         "task": NewsCategorizationTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/news_categorization/ASND_GPT4_ZeroShot.py
+++ b/assets/ar/news_categorization/ASND_GPT4_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ASNDDataset,
-        "dataset_args": {},
         "task": NewsCategorizationTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/news_categorization/ASND_Random.py
+++ b/assets/ar/news_categorization/ASND_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ASNDDataset,
-        "dataset_args": {},
         "task": NewsCategorizationTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/assets/ar/news_categorization/SANADAkhbarona_BLOOMZ_ZeroShot.py
+++ b/assets/ar/news_categorization/SANADAkhbarona_BLOOMZ_ZeroShot.py
@@ -19,9 +19,7 @@ def metadata():
 def config():
     return {
         "dataset": SANADAkhbaronaDataset,
-        "dataset_args": {},
         "task": NewsCategorizationTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/news_categorization/SANADAkhbarona_GPT35_ZeroShot.py
+++ b/assets/ar/news_categorization/SANADAkhbarona_GPT35_ZeroShot.py
@@ -19,9 +19,7 @@ def metadata():
 def config():
     return {
         "dataset": SANADAkhbaronaDataset,
-        "dataset_args": {},
         "task": NewsCategorizationTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/news_categorization/SANADAkhbarona_GPT4_FewShot.py
+++ b/assets/ar/news_categorization/SANADAkhbarona_GPT4_FewShot.py
@@ -20,9 +20,7 @@ def metadata():
 def config():
     return {
         "dataset": SANADAkhbaronaDataset,
-        "dataset_args": {},
         "task": NewsCategorizationTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/news_categorization/SANADAkhbarona_GPT4_ZeroShot.py
+++ b/assets/ar/news_categorization/SANADAkhbarona_GPT4_ZeroShot.py
@@ -20,9 +20,7 @@ def metadata():
 def config():
     return {
         "dataset": SANADAkhbaronaDataset,
-        "dataset_args": {},
         "task": NewsCategorizationTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/news_categorization/SANADAkhbarona_Random.py
+++ b/assets/ar/news_categorization/SANADAkhbarona_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": SANADAkhbaronaDataset,
-        "dataset_args": {},
         "task": NewsCategorizationTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/assets/ar/news_categorization/SANADAlArabiya_BLOOMZ_ZeroShot.py
+++ b/assets/ar/news_categorization/SANADAlArabiya_BLOOMZ_ZeroShot.py
@@ -19,9 +19,7 @@ def metadata():
 def config():
     return {
         "dataset": SANADAlArabiyaDataset,
-        "dataset_args": {},
         "task": NewsCategorizationTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/news_categorization/SANADAlArabiya_GPT35_ZeroShot.py
+++ b/assets/ar/news_categorization/SANADAlArabiya_GPT35_ZeroShot.py
@@ -19,9 +19,7 @@ def metadata():
 def config():
     return {
         "dataset": SANADAlArabiyaDataset,
-        "dataset_args": {},
         "task": NewsCategorizationTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/news_categorization/SANADAlArabiya_GPT4_FewShot.py
+++ b/assets/ar/news_categorization/SANADAlArabiya_GPT4_FewShot.py
@@ -20,9 +20,7 @@ def metadata():
 def config():
     return {
         "dataset": SANADAlArabiyaDataset,
-        "dataset_args": {},
         "task": NewsCategorizationTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/news_categorization/SANADAlArabiya_GPT4_ZeroShot.py
+++ b/assets/ar/news_categorization/SANADAlArabiya_GPT4_ZeroShot.py
@@ -20,9 +20,7 @@ def metadata():
 def config():
     return {
         "dataset": SANADAlArabiyaDataset,
-        "dataset_args": {},
         "task": NewsCategorizationTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/news_categorization/SANADAlArabiya_Random.py
+++ b/assets/ar/news_categorization/SANADAlArabiya_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": SANADAlArabiyaDataset,
-        "dataset_args": {},
         "task": NewsCategorizationTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/assets/ar/news_categorization/SANADAlKhaleej_BLOOMZ_ZeroShot.py
+++ b/assets/ar/news_categorization/SANADAlKhaleej_BLOOMZ_ZeroShot.py
@@ -19,9 +19,7 @@ def metadata():
 def config():
     return {
         "dataset": SANADAlKhaleejDataset,
-        "dataset_args": {},
         "task": NewsCategorizationTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/news_categorization/SANADAlKhaleej_GPT35_ZeroShot.py
+++ b/assets/ar/news_categorization/SANADAlKhaleej_GPT35_ZeroShot.py
@@ -19,9 +19,7 @@ def metadata():
 def config():
     return {
         "dataset": SANADAlKhaleejDataset,
-        "dataset_args": {},
         "task": NewsCategorizationTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/news_categorization/SANADAlKhaleej_GPT4_FewShot.py
+++ b/assets/ar/news_categorization/SANADAlKhaleej_GPT4_FewShot.py
@@ -20,9 +20,7 @@ def metadata():
 def config():
     return {
         "dataset": SANADAlKhaleejDataset,
-        "dataset_args": {},
         "task": NewsCategorizationTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/news_categorization/SANADAlKhaleej_GPT4_ZeroShot.py
+++ b/assets/ar/news_categorization/SANADAlKhaleej_GPT4_ZeroShot.py
@@ -20,9 +20,7 @@ def metadata():
 def config():
     return {
         "dataset": SANADAlKhaleejDataset,
-        "dataset_args": {},
         "task": NewsCategorizationTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/news_categorization/SANADAlKhaleej_Random.py
+++ b/assets/ar/news_categorization/SANADAlKhaleej_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": SANADAlKhaleejDataset,
-        "dataset_args": {},
         "task": NewsCategorizationTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/assets/ar/semantics/NLI/XNLI_BLOOMZ_ZeroShot.py
+++ b/assets/ar/semantics/NLI/XNLI_BLOOMZ_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": XNLIDataset,
-        "dataset_args": {},
         "task": XNLITask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/semantics/NLI/XNLI_GPT35_ZeroShot.py
+++ b/assets/ar/semantics/NLI/XNLI_GPT35_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": XNLIDataset,
-        "dataset_args": {},
         "task": XNLITask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/semantics/NLI/XNLI_GPT4_FewShot.py
+++ b/assets/ar/semantics/NLI/XNLI_GPT4_FewShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": XNLIDataset,
-        "dataset_args": {},
         "task": XNLITask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/semantics/NLI/XNLI_GPT4_ZeroShot.py
+++ b/assets/ar/semantics/NLI/XNLI_GPT4_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": XNLIDataset,
-        "dataset_args": {},
         "task": XNLITask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/semantics/NLI/XNLI_Random.py
+++ b/assets/ar/semantics/NLI/XNLI_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": XNLIDataset,
-        "dataset_args": {},
         "task": XNLITask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/assets/ar/semantics/STS/Q2QSim_BLOOMZ_ZeroShot.py
+++ b/assets/ar/semantics/STS/Q2QSim_BLOOMZ_ZeroShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": STSQ2QDataset,
-        "dataset_args": {},
         "task": Q2QSimDetectionTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/semantics/STS/Q2QSim_GPT35_ZeroShot.py
+++ b/assets/ar/semantics/STS/Q2QSim_GPT35_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": STSQ2QDataset,
-        "dataset_args": {},
         "task": Q2QSimDetectionTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/semantics/STS/Q2QSim_GPT4_FewShot.py
+++ b/assets/ar/semantics/STS/Q2QSim_GPT4_FewShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": STSQ2QDataset,
-        "dataset_args": {},
         "task": Q2QSimDetectionTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/semantics/STS/Q2QSim_GPT4_ZeroShot.py
+++ b/assets/ar/semantics/STS/Q2QSim_GPT4_ZeroShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": STSQ2QDataset,
-        "dataset_args": {},
         "task": Q2QSimDetectionTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/semantics/STS/Q2QSim_Intfloat_Multilingual_e5_small_ZeroShot.py
+++ b/assets/ar/semantics/STS/Q2QSim_Intfloat_Multilingual_e5_small_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": STSQ2QDataset,
-        "dataset_args": {},
         "task": Q2QSimDetectionTask,
-        "task_args": {},
         "model": HuggingFaceInferenceAPIModel,
         "model_args": {
             "task_type": HuggingFaceTaskTypes.Sentence_Similarity,

--- a/assets/ar/semantics/STS/Q2QSim_Random.py
+++ b/assets/ar/semantics/STS/Q2QSim_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": STSQ2QDataset,
-        "dataset_args": {},
         "task": Q2QSimDetectionTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/assets/ar/semantics/STS/SemEval17T1STS_BLOOMZ_ZeroShot.py
+++ b/assets/ar/semantics/STS/SemEval17T1STS_BLOOMZ_ZeroShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": SemEval17T1STSDataset,
-        "dataset_args": {},
         "task": STSTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/semantics/STS/SemEval17T1STS_GPT35_ZeroShot.py
+++ b/assets/ar/semantics/STS/SemEval17T1STS_GPT35_ZeroShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": SemEval17T1STSDataset,
-        "dataset_args": {},
         "task": STSTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/semantics/STS/SemEval17T1STS_GPT4_FewShot.py
+++ b/assets/ar/semantics/STS/SemEval17T1STS_GPT4_FewShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": SemEval17T1STSDataset,
-        "dataset_args": {},
         "task": STSTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/semantics/STS/SemEval17T1STS_GPT4_ZeroShot.py
+++ b/assets/ar/semantics/STS/SemEval17T1STS_GPT4_ZeroShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": SemEval17T1STSDataset,
-        "dataset_args": {},
         "task": STSTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/semantics/STS/SemEval17T1STS_Random.py
+++ b/assets/ar/semantics/STS/SemEval17T1STS_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": SemEval17T1STSDataset,
-        "dataset_args": {},
         "task": STSTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {"task_type": TaskType.Regression, "score_range": (0, 5)},
         "general_args": {},

--- a/assets/ar/semantics/STS/SemEval17T2STS_BLOOMZ_ZeroShot.py
+++ b/assets/ar/semantics/STS/SemEval17T2STS_BLOOMZ_ZeroShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": SemEval17T2STSDataset,
-        "dataset_args": {},
         "task": STSTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/semantics/STS/SemEval17T2STS_GPT35_ZeroShot.py
+++ b/assets/ar/semantics/STS/SemEval17T2STS_GPT35_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": SemEval17T2STSDataset,
-        "dataset_args": {},
         "task": STSTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/semantics/STS/SemEval17T2STS_GPT4_FewShot.py
+++ b/assets/ar/semantics/STS/SemEval17T2STS_GPT4_FewShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": SemEval17T2STSDataset,
-        "dataset_args": {},
         "task": STSTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/semantics/STS/SemEval17T2STS_GPT4_ZeroShot.py
+++ b/assets/ar/semantics/STS/SemEval17T2STS_GPT4_ZeroShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": SemEval17T2STSDataset,
-        "dataset_args": {},
         "task": STSTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/semantics/STS/SemEval17T2STS_Random.py
+++ b/assets/ar/semantics/STS/SemEval17T2STS_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": SemEval17T2STSDataset,
-        "dataset_args": {},
         "task": STSTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {"task_type": TaskType.Regression, "score_range": (0, 5)},
         "general_args": {},

--- a/assets/ar/sentiment_emotion_others/emotion/Emotion_BLOOMZ_ZeroShot.py
+++ b/assets/ar/sentiment_emotion_others/emotion/Emotion_BLOOMZ_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": EmotionDataset,
-        "dataset_args": {},
         "task": EmotionTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/sentiment_emotion_others/emotion/Emotion_GPT35_ZeroShot.py
+++ b/assets/ar/sentiment_emotion_others/emotion/Emotion_GPT35_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": EmotionDataset,
-        "dataset_args": {},
         "task": EmotionTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/sentiment_emotion_others/emotion/Emotion_GPT4_FewShot.py
+++ b/assets/ar/sentiment_emotion_others/emotion/Emotion_GPT4_FewShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": EmotionDataset,
-        "dataset_args": {},
         "task": EmotionTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/sentiment_emotion_others/emotion/Emotion_GPT4_ZeroShot.py
+++ b/assets/ar/sentiment_emotion_others/emotion/Emotion_GPT4_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": EmotionDataset,
-        "dataset_args": {},
         "task": EmotionTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/sentiment_emotion_others/emotion/Emotion_Random.py
+++ b/assets/ar/sentiment_emotion_others/emotion/Emotion_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": EmotionDataset,
-        "dataset_args": {},
         "task": EmotionTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.MultiLabelClassification,

--- a/assets/ar/sentiment_emotion_others/sarcasm/ArSarcasm2_BLOOMZ_ZeroShot.py
+++ b/assets/ar/sentiment_emotion_others/sarcasm/ArSarcasm2_BLOOMZ_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ArSarcasm2Dataset,
-        "dataset_args": {},
         "task": SarcasmTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": ["TRUE", "FALSE"],

--- a/assets/ar/sentiment_emotion_others/sarcasm/ArSarcasm2_GPT35_ZeroShot.py
+++ b/assets/ar/sentiment_emotion_others/sarcasm/ArSarcasm2_GPT35_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ArSarcasm2Dataset,
-        "dataset_args": {},
         "task": SarcasmTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "class_labels": ["TRUE", "FALSE"],

--- a/assets/ar/sentiment_emotion_others/sarcasm/ArSarcasm2_GPT4_FewShot.py
+++ b/assets/ar/sentiment_emotion_others/sarcasm/ArSarcasm2_GPT4_FewShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ArSarcasm2Dataset,
-        "dataset_args": {},
         "task": SarcasmTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["TRUE", "FALSE"],

--- a/assets/ar/sentiment_emotion_others/sarcasm/ArSarcasm2_GPT4_ZeroShot.py
+++ b/assets/ar/sentiment_emotion_others/sarcasm/ArSarcasm2_GPT4_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ArSarcasm2Dataset,
-        "dataset_args": {},
         "task": SarcasmTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["TRUE", "FALSE"],

--- a/assets/ar/sentiment_emotion_others/sarcasm/ArSarcasm2_Random.py
+++ b/assets/ar/sentiment_emotion_others/sarcasm/ArSarcasm2_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ArSarcasm2Dataset,
-        "dataset_args": {},
         "task": SarcasmTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/assets/ar/sentiment_emotion_others/sarcasm/ArSarcasm_BLOOMZ_ZeroShot.py
+++ b/assets/ar/sentiment_emotion_others/sarcasm/ArSarcasm_BLOOMZ_ZeroShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": ArSarcasmDataset,
-        "dataset_args": {},
         "task": SarcasmTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": ["TRUE", "FALSE"],

--- a/assets/ar/sentiment_emotion_others/sarcasm/ArSarcasm_GPT35_ZeroShot.py
+++ b/assets/ar/sentiment_emotion_others/sarcasm/ArSarcasm_GPT35_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ArSarcasmDataset,
-        "dataset_args": {},
         "task": SarcasmTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "class_labels": ["TRUE", "FALSE"],

--- a/assets/ar/sentiment_emotion_others/sarcasm/ArSarcasm_GPT4_FewShot.py
+++ b/assets/ar/sentiment_emotion_others/sarcasm/ArSarcasm_GPT4_FewShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ArSarcasmDataset,
-        "dataset_args": {},
         "task": SarcasmTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["TRUE", "FALSE"],

--- a/assets/ar/sentiment_emotion_others/sarcasm/ArSarcasm_GPT4_ZeroShot.py
+++ b/assets/ar/sentiment_emotion_others/sarcasm/ArSarcasm_GPT4_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ArSarcasmDataset,
-        "dataset_args": {},
         "task": SarcasmTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["TRUE", "FALSE"],

--- a/assets/ar/sentiment_emotion_others/sarcasm/ArSarcasm_Random.py
+++ b/assets/ar/sentiment_emotion_others/sarcasm/ArSarcasm_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ArSarcasmDataset,
-        "dataset_args": {},
         "task": SarcasmTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/assets/ar/sentiment_emotion_others/sentiment/ArSAS_BLOOMZ_ZeroShot.py
+++ b/assets/ar/sentiment_emotion_others/sentiment/ArSAS_BLOOMZ_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ArSASDataset,
-        "dataset_args": {},
         "task": SentimentTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": ["Positive", "Negative", "Neutral", "Mixed"],

--- a/assets/ar/sentiment_emotion_others/sentiment/ArSAS_Camelbert_da_sentiment_ZeroShot.py
+++ b/assets/ar/sentiment_emotion_others/sentiment/ArSAS_Camelbert_da_sentiment_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ArSASDataset,
-        "dataset_args": {},
         "task": SentimentTask,
-        "task_args": {},
         "model": HuggingFaceInferenceAPIModel,
         "model_args": {
             "task_type": HuggingFaceTaskTypes.Text_Classification,

--- a/assets/ar/sentiment_emotion_others/sentiment/ArSAS_GPT35_ZeroShot.py
+++ b/assets/ar/sentiment_emotion_others/sentiment/ArSAS_GPT35_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ArSASDataset,
-        "dataset_args": {},
         "task": SentimentTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "class_labels": ["Positive", "Negative", "Neutral", "Mixed"],

--- a/assets/ar/sentiment_emotion_others/sentiment/ArSAS_GPT4_FewShot.py
+++ b/assets/ar/sentiment_emotion_others/sentiment/ArSAS_GPT4_FewShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": ArSASDataset,
-        "dataset_args": {},
         "task": SentimentTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["Positive", "Negative", "Neutral", "Mixed"],

--- a/assets/ar/sentiment_emotion_others/sentiment/ArSAS_GPT4_ZeroShot.py
+++ b/assets/ar/sentiment_emotion_others/sentiment/ArSAS_GPT4_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ArSASDataset,
-        "dataset_args": {},
         "task": SentimentTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["Positive", "Negative", "Neutral", "Mixed"],

--- a/assets/ar/sentiment_emotion_others/sentiment/ArSAS_Random.py
+++ b/assets/ar/sentiment_emotion_others/sentiment/ArSAS_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ArSASDataset,
-        "dataset_args": {},
         "task": SentimentTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/assets/ar/sentiment_emotion_others/stance_detection/ANSStance_BLOOMZ_ZeroShot.py
+++ b/assets/ar/sentiment_emotion_others/stance_detection/ANSStance_BLOOMZ_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ANSStanceDataset,
-        "dataset_args": {},
         "task": StanceTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": ["agree", "disagree"],

--- a/assets/ar/sentiment_emotion_others/stance_detection/ANSStance_GPT35_ZeroShot.py
+++ b/assets/ar/sentiment_emotion_others/stance_detection/ANSStance_GPT35_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ANSStanceDataset,
-        "dataset_args": {},
         "task": StanceTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "class_labels": ["agree", "disagree"],

--- a/assets/ar/sentiment_emotion_others/stance_detection/ANSStance_GPT4_FewShot.py
+++ b/assets/ar/sentiment_emotion_others/stance_detection/ANSStance_GPT4_FewShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ANSStanceDataset,
-        "dataset_args": {},
         "task": StanceTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["agree", "disagree"],

--- a/assets/ar/sentiment_emotion_others/stance_detection/ANSStance_GPT4_ZeroShot.py
+++ b/assets/ar/sentiment_emotion_others/stance_detection/ANSStance_GPT4_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ANSStanceDataset,
-        "dataset_args": {},
         "task": StanceTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["agree", "disagree"],

--- a/assets/ar/sentiment_emotion_others/stance_detection/ANSStance_Random.py
+++ b/assets/ar/sentiment_emotion_others/stance_detection/ANSStance_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ANSStanceDataset,
-        "dataset_args": {},
         "task": StanceTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/assets/ar/sentiment_emotion_others/stance_detection/UnifiedFCStance_BLOOMZ_ZeroShot.py
+++ b/assets/ar/sentiment_emotion_others/stance_detection/UnifiedFCStance_BLOOMZ_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": UnifiedFCStanceDataset,
-        "dataset_args": {},
         "task": StanceTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": ["agree", "disagree", "discuss", "unrelated"],

--- a/assets/ar/sentiment_emotion_others/stance_detection/UnifiedFCStance_GPT35_ZeroShot.py
+++ b/assets/ar/sentiment_emotion_others/stance_detection/UnifiedFCStance_GPT35_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": UnifiedFCStanceDataset,
-        "dataset_args": {},
         "task": StanceTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "class_labels": ["agree", "disagree", "unrelated"],

--- a/assets/ar/sentiment_emotion_others/stance_detection/UnifiedFCStance_GPT4_FewShot.py
+++ b/assets/ar/sentiment_emotion_others/stance_detection/UnifiedFCStance_GPT4_FewShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": UnifiedFCStanceDataset,
-        "dataset_args": {},
         "task": StanceTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/sentiment_emotion_others/stance_detection/UnifiedFCStance_GPT4_ZeroShot.py
+++ b/assets/ar/sentiment_emotion_others/stance_detection/UnifiedFCStance_GPT4_ZeroShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": UnifiedFCStanceDataset,
-        "dataset_args": {},
         "task": StanceTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/sentiment_emotion_others/stance_detection/UnifiedFCStance_Random.py
+++ b/assets/ar/sentiment_emotion_others/stance_detection/UnifiedFCStance_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": UnifiedFCStanceDataset,
-        "dataset_args": {},
         "task": StanceTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/assets/ar/sequence_tagging_and_information_extraction/NER/ANERcorp_GPT35_ZeroShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/NER/ANERcorp_GPT35_ZeroShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": ANERcorpDataset,
-        "dataset_args": {},
         "task": NERTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/sequence_tagging_and_information_extraction/NER/ANERcorp_GPT4_FewShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/NER/ANERcorp_GPT4_FewShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": ANERcorpDataset,
-        "dataset_args": {},
         "task": NERTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/sequence_tagging_and_information_extraction/NER/ANERcorp_GPT4_ZeroShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/NER/ANERcorp_GPT4_ZeroShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": ANERcorpDataset,
-        "dataset_args": {},
         "task": NERTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/sequence_tagging_and_information_extraction/NER/ANERcorp_Random.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/NER/ANERcorp_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ANERcorpDataset,
-        "dataset_args": {},
         "task": NERTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.SequenceLabeling,

--- a/assets/ar/sequence_tagging_and_information_extraction/NER/Aqmar_GPT35_ZeroShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/NER/Aqmar_GPT35_ZeroShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": AqmarDataset,
-        "dataset_args": {},
         "task": NERTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/sequence_tagging_and_information_extraction/NER/Aqmar_GPT4_FewShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/NER/Aqmar_GPT4_FewShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": AqmarDataset,
-        "dataset_args": {},
         "task": NERTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/sequence_tagging_and_information_extraction/NER/Aqmar_GPT4_ZeroShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/NER/Aqmar_GPT4_ZeroShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": AqmarDataset,
-        "dataset_args": {},
         "task": NERTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/sequence_tagging_and_information_extraction/NER/Aqmar_Random.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/NER/Aqmar_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": AqmarDataset,
-        "dataset_args": {},
         "task": NERTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.SequenceLabeling,

--- a/assets/ar/sequence_tagging_and_information_extraction/NER/MGBWords_GPT35_ZeroShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/NER/MGBWords_GPT35_ZeroShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": MGBWordsDataset,
-        "dataset_args": {},
         "task": NERTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/sequence_tagging_and_information_extraction/NER/MGBWords_GPT4_ZeroShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/NER/MGBWords_GPT4_ZeroShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": MGBWordsDataset,
-        "dataset_args": {},
         "task": NERTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/sequence_tagging_and_information_extraction/NER/MGBWords_Random.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/NER/MGBWords_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": MGBWordsDataset,
-        "dataset_args": {},
         "task": NERTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.SequenceLabeling,

--- a/assets/ar/sequence_tagging_and_information_extraction/POS/QCRIDialectalArabic_GPT35_ZeroShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/POS/QCRIDialectalArabic_GPT35_ZeroShot.py
@@ -105,9 +105,7 @@ def metadata():
 def config():
     return {
         "dataset": QCRIDialectalArabicPOSDataset,
-        "dataset_args": {},
         "task": ArabicPOSTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/sequence_tagging_and_information_extraction/POS/QCRIDialectalArabic_GPT4_FewShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/POS/QCRIDialectalArabic_GPT4_FewShot.py
@@ -105,9 +105,7 @@ def metadata():
 def config():
     return {
         "dataset": QCRIDialectalArabicPOSDataset,
-        "dataset_args": {},
         "task": ArabicPOSTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 30,

--- a/assets/ar/sequence_tagging_and_information_extraction/POS/QCRIDialectalArabic_GPT4_ZeroShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/POS/QCRIDialectalArabic_GPT4_ZeroShot.py
@@ -105,9 +105,7 @@ def metadata():
 def config():
     return {
         "dataset": QCRIDialectalArabicPOSDataset,
-        "dataset_args": {},
         "task": ArabicPOSTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/sequence_tagging_and_information_extraction/POS/QCRIDialectalArabic_Random.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/POS/QCRIDialectalArabic_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": QCRIDialectalArabicPOSDataset,
-        "dataset_args": {},
         "task": ArabicPOSTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.SequenceLabeling,

--- a/assets/ar/sequence_tagging_and_information_extraction/POS/WikiNews_GPT35_ZeroShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/POS/WikiNews_GPT35_ZeroShot.py
@@ -105,9 +105,7 @@ def metadata():
 def config():
     return {
         "dataset": WikiNewsPOSDataset,
-        "dataset_args": {},
         "task": ArabicPOSTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/sequence_tagging_and_information_extraction/POS/WikiNews_GPT4_FewShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/POS/WikiNews_GPT4_FewShot.py
@@ -105,9 +105,7 @@ def metadata():
 def config():
     return {
         "dataset": WikiNewsPOSDataset,
-        "dataset_args": {},
         "task": ArabicPOSTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 30,

--- a/assets/ar/sequence_tagging_and_information_extraction/POS/WikiNews_GPT4_ZeroShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/POS/WikiNews_GPT4_ZeroShot.py
@@ -105,9 +105,7 @@ def metadata():
 def config():
     return {
         "dataset": WikiNewsPOSDataset,
-        "dataset_args": {},
         "task": ArabicPOSTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/sequence_tagging_and_information_extraction/POS/WikiNews_Random.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/POS/WikiNews_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": WikiNewsPOSDataset,
-        "dataset_args": {},
         "task": ArabicPOSTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.SequenceLabeling,

--- a/assets/ar/sequence_tagging_and_information_extraction/POS/XGLUE_GPT35_ZeroShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/POS/XGLUE_GPT35_ZeroShot.py
@@ -105,9 +105,7 @@ def metadata():
 def config():
     return {
         "dataset": XGLUEPOSDataset,
-        "dataset_args": {},
         "task": ArabicPOSTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/sequence_tagging_and_information_extraction/POS/XGLUE_GPT4_FewShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/POS/XGLUE_GPT4_FewShot.py
@@ -105,9 +105,7 @@ def metadata():
 def config():
     return {
         "dataset": XGLUEPOSDataset,
-        "dataset_args": {},
         "task": ArabicPOSTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 30,

--- a/assets/ar/sequence_tagging_and_information_extraction/POS/XGLUE_GPT4_ZeroShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/POS/XGLUE_GPT4_ZeroShot.py
@@ -105,9 +105,7 @@ def metadata():
 def config():
     return {
         "dataset": XGLUEPOSDataset,
-        "dataset_args": {},
         "task": ArabicPOSTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/sequence_tagging_and_information_extraction/POS/XGLUE_Random.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/POS/XGLUE_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": XGLUEPOSDataset,
-        "dataset_args": {},
         "task": ArabicPOSTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.SequenceLabeling,

--- a/assets/ar/sequence_tagging_and_information_extraction/diacritization/BibleMaghrebi_GPT35_ZeroShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/diacritization/BibleMaghrebi_GPT35_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": BibleMaghrebiDiacritizationDataset,
-        "dataset_args": {},
         "task": ArabicDiacritizationTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/sequence_tagging_and_information_extraction/diacritization/BibleMaghrebi_GPT4_FewShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/diacritization/BibleMaghrebi_GPT4_FewShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": BibleMaghrebiDiacritizationDataset,
-        "dataset_args": {},
         "task": ArabicDiacritizationTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/sequence_tagging_and_information_extraction/diacritization/BibleMaghrebi_GPT4_ZeroShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/diacritization/BibleMaghrebi_GPT4_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": BibleMaghrebiDiacritizationDataset,
-        "dataset_args": {},
         "task": ArabicDiacritizationTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/sequence_tagging_and_information_extraction/diacritization/BibleMaghrebi_Random.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/diacritization/BibleMaghrebi_Random.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": BibleMaghrebiDiacritizationDataset,
-        "dataset_args": {},
         "task": ArabicDiacritizationTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {"task_type": TaskType.Other},
         "general_args": {},

--- a/assets/ar/sequence_tagging_and_information_extraction/diacritization/WikiNews_GPT35_ZeroShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/diacritization/WikiNews_GPT35_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": WikiNewsDiacritizationDataset,
-        "dataset_args": {},
         "task": ArabicDiacritizationTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/sequence_tagging_and_information_extraction/diacritization/WikiNews_GPT4_FewShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/diacritization/WikiNews_GPT4_FewShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": WikiNewsDiacritizationDataset,
-        "dataset_args": {},
         "task": ArabicDiacritizationTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/sequence_tagging_and_information_extraction/diacritization/WikiNews_GPT4_ZeroShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/diacritization/WikiNews_GPT4_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": WikiNewsDiacritizationDataset,
-        "dataset_args": {},
         "task": ArabicDiacritizationTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/sequence_tagging_and_information_extraction/diacritization/WikiNews_Random.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/diacritization/WikiNews_Random.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": WikiNewsDiacritizationDataset,
-        "dataset_args": {},
         "task": ArabicDiacritizationTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {"task_type": TaskType.Other},
         "general_args": {},

--- a/assets/ar/sequence_tagging_and_information_extraction/dialect_identification/ADI_BLOOMZ_ZeroShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/dialect_identification/ADI_BLOOMZ_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ADIDataset,
-        "dataset_args": {},
         "task": DialectIDTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/sequence_tagging_and_information_extraction/dialect_identification/ADI_GPT35_ZeroShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/dialect_identification/ADI_GPT35_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ADIDataset,
-        "dataset_args": {},
         "task": DialectIDTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/sequence_tagging_and_information_extraction/dialect_identification/ADI_GPT4_FewShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/dialect_identification/ADI_GPT4_FewShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ADIDataset,
-        "dataset_args": {},
         "task": DialectIDTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/sequence_tagging_and_information_extraction/dialect_identification/ADI_GPT4_ZeroShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/dialect_identification/ADI_GPT4_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ADIDataset,
-        "dataset_args": {},
         "task": DialectIDTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/sequence_tagging_and_information_extraction/dialect_identification/ADI_Random.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/dialect_identification/ADI_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": ADIDataset,
-        "dataset_args": {},
         "task": DialectIDTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/assets/ar/sequence_tagging_and_information_extraction/dialect_identification/QADI_BLOOMZ_ZeroShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/dialect_identification/QADI_BLOOMZ_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": QADIDataset,
-        "dataset_args": {},
         "task": DialectIDTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/sequence_tagging_and_information_extraction/dialect_identification/QADI_GPT35_ZeroShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/dialect_identification/QADI_GPT35_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": QADIDataset,
-        "dataset_args": {},
         "task": DialectIDTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/sequence_tagging_and_information_extraction/dialect_identification/QADI_GPT4_ZeroShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/dialect_identification/QADI_GPT4_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": QADIDataset,
-        "dataset_args": {},
         "task": DialectIDTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ar/sequence_tagging_and_information_extraction/dialect_identification/QADI_Random.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/dialect_identification/QADI_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": QADIDataset,
-        "dataset_args": {},
         "task": DialectIDTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/assets/ar/sequence_tagging_and_information_extraction/lemmatization/WikiNews_BLOOMZ_ZeroShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/lemmatization/WikiNews_BLOOMZ_ZeroShot.py
@@ -14,9 +14,7 @@ def metadata():
 def config():
     return {
         "dataset": WikiNewsLemmatizationDataset,
-        "dataset_args": {},
         "task": LemmatizationTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/sequence_tagging_and_information_extraction/lemmatization/WikiNews_GPT35_ZeroShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/lemmatization/WikiNews_GPT35_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": WikiNewsLemmatizationDataset,
-        "dataset_args": {},
         "task": LemmatizationTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/sequence_tagging_and_information_extraction/lemmatization/WikiNews_GPT4_ZeroShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/lemmatization/WikiNews_GPT4_ZeroShot.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": WikiNewsLemmatizationDataset,
-        "dataset_args": {},
         "task": LemmatizationTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/sequence_tagging_and_information_extraction/lemmatization/WikiNews_Random.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/lemmatization/WikiNews_Random.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": WikiNewsLemmatizationDataset,
-        "dataset_args": {},
         "task": LemmatizationTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {"task_type": TaskType.Other},
         "general_args": {},

--- a/assets/ar/sequence_tagging_and_information_extraction/parsing/PADT_GPT35_ZeroShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/parsing/PADT_GPT35_ZeroShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": PADTDataset,
-        "dataset_args": {},
         "task": ArabicParsingTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/sequence_tagging_and_information_extraction/parsing/PADT_GPT4_FewShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/parsing/PADT_GPT4_FewShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": PADTDataset,
-        "dataset_args": {},
         "task": ArabicParsingTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/sequence_tagging_and_information_extraction/parsing/PADT_GPT4_ZeroShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/parsing/PADT_GPT4_ZeroShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": PADTDataset,
-        "dataset_args": {},
         "task": ArabicParsingTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/sequence_tagging_and_information_extraction/parsing/PADT_Random.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/parsing/PADT_Random.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": PADTDataset,
-        "dataset_args": {},
         "task": ArabicParsingTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {"task_type": TaskType.Other},
         "general_args": {},

--- a/assets/ar/sequence_tagging_and_information_extraction/segmentation/QCRIDialectalArabic_GPT35_ZeroShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/segmentation/QCRIDialectalArabic_GPT35_ZeroShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": QCRIDialectalArabicSegmentationDataset,
-        "dataset_args": {},
         "task": ArabicSegmentationTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/sequence_tagging_and_information_extraction/segmentation/QCRIDialectalArabic_GPT4_FewShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/segmentation/QCRIDialectalArabic_GPT4_FewShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": QCRIDialectalArabicSegmentationDataset,
-        "dataset_args": {},
         "task": ArabicSegmentationTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/sequence_tagging_and_information_extraction/segmentation/QCRIDialectalArabic_GPT4_ZeroShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/segmentation/QCRIDialectalArabic_GPT4_ZeroShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": QCRIDialectalArabicSegmentationDataset,
-        "dataset_args": {},
         "task": ArabicSegmentationTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/sequence_tagging_and_information_extraction/segmentation/QCRIDialectalArabic_Random.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/segmentation/QCRIDialectalArabic_Random.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": QCRIDialectalArabicSegmentationDataset,
-        "dataset_args": {},
         "task": ArabicSegmentationTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {"task_type": TaskType.Other},
         "general_args": {},

--- a/assets/ar/sequence_tagging_and_information_extraction/segmentation/WikiNews_GPT35_ZeroShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/segmentation/WikiNews_GPT35_ZeroShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": WikiNewsSegmentationDataset,
-        "dataset_args": {},
         "task": ArabicSegmentationTask,
-        "task_args": {},
         "model": LegacyOpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/sequence_tagging_and_information_extraction/segmentation/WikiNews_GPT4_FewShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/segmentation/WikiNews_GPT4_FewShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": WikiNewsSegmentationDataset,
-        "dataset_args": {},
         "task": ArabicSegmentationTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/sequence_tagging_and_information_extraction/segmentation/WikiNews_GPT4_ZeroShot.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/segmentation/WikiNews_GPT4_ZeroShot.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": WikiNewsSegmentationDataset,
-        "dataset_args": {},
         "task": ArabicSegmentationTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "max_tries": 3,

--- a/assets/ar/sequence_tagging_and_information_extraction/segmentation/WikiNews_Random.py
+++ b/assets/ar/sequence_tagging_and_information_extraction/segmentation/WikiNews_Random.py
@@ -17,9 +17,7 @@ def metadata():
 def config():
     return {
         "dataset": WikiNewsSegmentationDataset,
-        "dataset_args": {},
         "task": ArabicSegmentationTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {"task_type": TaskType.Other},
         "general_args": {},

--- a/assets/bg/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_BLOOMZ_ZeroShot.py
+++ b/assets/bg/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_BLOOMZ_ZeroShot.py
@@ -14,9 +14,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22CheckworthinessDataset,
-        "dataset_args": {},
         "task": CheckworthinessTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": ["0", "1"],

--- a/assets/bg/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_GPT4_FewShot.py
+++ b/assets/bg/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_GPT4_FewShot.py
@@ -16,9 +16,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22CheckworthinessDataset,
-        "dataset_args": {},
         "task": CheckworthinessTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["0", "1"],

--- a/assets/bg/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_GPT4_ZeroShot.py
+++ b/assets/bg/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_GPT4_ZeroShot.py
@@ -16,9 +16,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22CheckworthinessDataset,
-        "dataset_args": {},
         "task": CheckworthinessTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["0", "1"],

--- a/assets/bg/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_Random.py
+++ b/assets/bg/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22CheckworthinessDataset,
-        "dataset_args": {},
         "task": CheckworthinessTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/assets/bn/sentiment_emotion_others/sentiment/BanglaSentiment_BLOOMZ_ZeroShot.py
+++ b/assets/bn/sentiment_emotion_others/sentiment/BanglaSentiment_BLOOMZ_ZeroShot.py
@@ -14,9 +14,7 @@ def metadata():
 def config():
     return {
         "dataset": BanglaSentimentDataset,
-        "dataset_args": {},
         "task": SentimentTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": ["Positive", "Negative", "Neutral"],

--- a/assets/bn/sentiment_emotion_others/sentiment/BanglaSentiment_GPT4_FewShot.py
+++ b/assets/bn/sentiment_emotion_others/sentiment/BanglaSentiment_GPT4_FewShot.py
@@ -14,9 +14,7 @@ def metadata():
 def config():
     return {
         "dataset": BanglaSentimentDataset,
-        "dataset_args": {},
         "task": SentimentTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["Positive", "Negative", "Neutral"],

--- a/assets/bn/sentiment_emotion_others/sentiment/BanglaSentiment_GPT4_ZeroShot.py
+++ b/assets/bn/sentiment_emotion_others/sentiment/BanglaSentiment_GPT4_ZeroShot.py
@@ -14,9 +14,7 @@ def metadata():
 def config():
     return {
         "dataset": BanglaSentimentDataset,
-        "dataset_args": {},
         "task": SentimentTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["Positive", "Negative", "Neutral"],

--- a/assets/bn/sentiment_emotion_others/sentiment/BanglaSentiment_Random.py
+++ b/assets/bn/sentiment_emotion_others/sentiment/BanglaSentiment_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": BanglaSentimentDataset,
-        "dataset_args": {},
         "task": SentimentTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/assets/de/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_BLOOMZ_ZeroShot.py
+++ b/assets/de/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_BLOOMZ_ZeroShot.py
@@ -18,7 +18,6 @@ def config():
         "dataset": SemEval23T3PropagandaDataset,
         "dataset_args": {"techniques_path": "techniques_subtask3.txt"},
         "task": MultilabelPropagandaTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": [

--- a/assets/de/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_GPT4_FewShot.py
+++ b/assets/de/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_GPT4_FewShot.py
@@ -18,7 +18,6 @@ def config():
         "dataset": SemEval23T3PropagandaDataset,
         "dataset_args": {"techniques_path": "techniques_subtask3.txt"},
         "task": MultilabelPropagandaTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/de/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_GPT4_ZeroShot.py
+++ b/assets/de/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_GPT4_ZeroShot.py
@@ -18,7 +18,6 @@ def config():
         "dataset": SemEval23T3PropagandaDataset,
         "dataset_args": {"techniques_path": "techniques_subtask3.txt"},
         "task": MultilabelPropagandaTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/de/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_Random.py
+++ b/assets/de/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_Random.py
@@ -17,7 +17,6 @@ def config():
         "dataset": SemEval23T3PropagandaDataset,
         "dataset_args": {"techniques_path": "techniques_subtask3.txt"},
         "task": MultilabelPropagandaTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.MultiLabelClassification,

--- a/assets/en/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_BLOOMZ_ZeroShot.py
+++ b/assets/en/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_BLOOMZ_ZeroShot.py
@@ -14,9 +14,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22CheckworthinessDataset,
-        "dataset_args": {},
         "task": CheckworthinessTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": ["0", "1"],

--- a/assets/en/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_GPT4_FewShot.py
+++ b/assets/en/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_GPT4_FewShot.py
@@ -16,9 +16,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22CheckworthinessDataset,
-        "dataset_args": {},
         "task": CheckworthinessTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["0", "1"],

--- a/assets/en/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_GPT4_ZeroShot.py
+++ b/assets/en/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_GPT4_ZeroShot.py
@@ -16,9 +16,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22CheckworthinessDataset,
-        "dataset_args": {},
         "task": CheckworthinessTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["0", "1"],

--- a/assets/en/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_Random.py
+++ b/assets/en/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22CheckworthinessDataset,
-        "dataset_args": {},
         "task": CheckworthinessTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/assets/en/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_BLOOMZ_ZeroShot.py
+++ b/assets/en/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_BLOOMZ_ZeroShot.py
@@ -18,7 +18,6 @@ def config():
         "dataset": SemEval23T3PropagandaDataset,
         "dataset_args": {"techniques_path": "techniques_subtask3.txt"},
         "task": MultilabelPropagandaTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": [

--- a/assets/en/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_GPT4_FewShot.py
+++ b/assets/en/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_GPT4_FewShot.py
@@ -18,7 +18,6 @@ def config():
         "dataset": SemEval23T3PropagandaDataset,
         "dataset_args": {"techniques_path": "techniques_subtask3.txt"},
         "task": MultilabelPropagandaTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/en/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_GPT4_ZeroShot.py
+++ b/assets/en/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_GPT4_ZeroShot.py
@@ -18,7 +18,6 @@ def config():
         "dataset": SemEval23T3PropagandaDataset,
         "dataset_args": {"techniques_path": "techniques_subtask3.txt"},
         "task": MultilabelPropagandaTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/en/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_Random.py
+++ b/assets/en/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_Random.py
@@ -17,7 +17,6 @@ def config():
         "dataset": SemEval23T3PropagandaDataset,
         "dataset_args": {"techniques_path": "techniques_subtask3.txt"},
         "task": MultilabelPropagandaTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.MultiLabelClassification,

--- a/assets/es/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_BLOOMZ_ZeroShot.py
+++ b/assets/es/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_BLOOMZ_ZeroShot.py
@@ -14,9 +14,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22CheckworthinessDataset,
-        "dataset_args": {},
         "task": CheckworthinessTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": ["0", "1"],

--- a/assets/es/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_GPT4_FewShot.py
+++ b/assets/es/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_GPT4_FewShot.py
@@ -16,9 +16,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22CheckworthinessDataset,
-        "dataset_args": {},
         "task": CheckworthinessTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["0", "1"],

--- a/assets/es/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_GPT4_ZeroShot.py
+++ b/assets/es/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_GPT4_ZeroShot.py
@@ -16,9 +16,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22CheckworthinessDataset,
-        "dataset_args": {},
         "task": CheckworthinessTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["0", "1"],

--- a/assets/es/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_Random.py
+++ b/assets/es/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22CheckworthinessDataset,
-        "dataset_args": {},
         "task": CheckworthinessTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/assets/fr/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_BLOOMZ_ZeroShot.py
+++ b/assets/fr/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_BLOOMZ_ZeroShot.py
@@ -18,7 +18,6 @@ def config():
         "dataset": SemEval23T3PropagandaDataset,
         "dataset_args": {"techniques_path": "techniques_subtask3.txt"},
         "task": MultilabelPropagandaTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": [

--- a/assets/fr/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_GPT4_FewShot.py
+++ b/assets/fr/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_GPT4_FewShot.py
@@ -18,7 +18,6 @@ def config():
         "dataset": SemEval23T3PropagandaDataset,
         "dataset_args": {"techniques_path": "techniques_subtask3.txt"},
         "task": MultilabelPropagandaTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/fr/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_GPT4_ZeroShot.py
+++ b/assets/fr/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_GPT4_ZeroShot.py
@@ -18,7 +18,6 @@ def config():
         "dataset": SemEval23T3PropagandaDataset,
         "dataset_args": {"techniques_path": "techniques_subtask3.txt"},
         "task": MultilabelPropagandaTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/fr/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_Random.py
+++ b/assets/fr/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_Random.py
@@ -17,7 +17,6 @@ def config():
         "dataset": SemEval23T3PropagandaDataset,
         "dataset_args": {"techniques_path": "techniques_subtask3.txt"},
         "task": MultilabelPropagandaTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.MultiLabelClassification,

--- a/assets/it/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_BLOOMZ_ZeroShot.py
+++ b/assets/it/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_BLOOMZ_ZeroShot.py
@@ -18,7 +18,6 @@ def config():
         "dataset": SemEval23T3PropagandaDataset,
         "dataset_args": {"techniques_path": "techniques_subtask3.txt"},
         "task": MultilabelPropagandaTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": [

--- a/assets/it/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_GPT4_FewShot.py
+++ b/assets/it/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_GPT4_FewShot.py
@@ -18,7 +18,6 @@ def config():
         "dataset": SemEval23T3PropagandaDataset,
         "dataset_args": {"techniques_path": "techniques_subtask3.txt"},
         "task": MultilabelPropagandaTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/it/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_GPT4_ZeroShot.py
+++ b/assets/it/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_GPT4_ZeroShot.py
@@ -18,7 +18,6 @@ def config():
         "dataset": SemEval23T3PropagandaDataset,
         "dataset_args": {"techniques_path": "techniques_subtask3.txt"},
         "task": MultilabelPropagandaTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/it/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_Random.py
+++ b/assets/it/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_Random.py
@@ -17,7 +17,6 @@ def config():
         "dataset": SemEval23T3PropagandaDataset,
         "dataset_args": {"techniques_path": "techniques_subtask3.txt"},
         "task": MultilabelPropagandaTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.MultiLabelClassification,

--- a/assets/nl/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_BLOOMZ_ZeroShot.py
+++ b/assets/nl/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_BLOOMZ_ZeroShot.py
@@ -14,9 +14,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22CheckworthinessDataset,
-        "dataset_args": {},
         "task": CheckworthinessTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": ["0", "1"],

--- a/assets/nl/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_GPT4_FewShot.py
+++ b/assets/nl/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_GPT4_FewShot.py
@@ -16,9 +16,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22CheckworthinessDataset,
-        "dataset_args": {},
         "task": CheckworthinessTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["0", "1"],

--- a/assets/nl/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_GPT4_ZeroShot.py
+++ b/assets/nl/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_GPT4_ZeroShot.py
@@ -16,9 +16,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22CheckworthinessDataset,
-        "dataset_args": {},
         "task": CheckworthinessTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["0", "1"],

--- a/assets/nl/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_Random.py
+++ b/assets/nl/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22CheckworthinessDataset,
-        "dataset_args": {},
         "task": CheckworthinessTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/assets/pl/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_BLOOMZ_ZeroShot.py
+++ b/assets/pl/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_BLOOMZ_ZeroShot.py
@@ -18,7 +18,6 @@ def config():
         "dataset": SemEval23T3PropagandaDataset,
         "dataset_args": {"techniques_path": "techniques_subtask3.txt"},
         "task": MultilabelPropagandaTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": [

--- a/assets/pl/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_GPT4_FewShot.py
+++ b/assets/pl/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_GPT4_FewShot.py
@@ -18,7 +18,6 @@ def config():
         "dataset": SemEval23T3PropagandaDataset,
         "dataset_args": {"techniques_path": "techniques_subtask3.txt"},
         "task": MultilabelPropagandaTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/pl/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_GPT4_ZeroShot.py
+++ b/assets/pl/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_GPT4_ZeroShot.py
@@ -18,7 +18,6 @@ def config():
         "dataset": SemEval23T3PropagandaDataset,
         "dataset_args": {"techniques_path": "techniques_subtask3.txt"},
         "task": MultilabelPropagandaTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/pl/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_Random.py
+++ b/assets/pl/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_Random.py
@@ -17,7 +17,6 @@ def config():
         "dataset": SemEval23T3PropagandaDataset,
         "dataset_args": {"techniques_path": "techniques_subtask3.txt"},
         "task": MultilabelPropagandaTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.MultiLabelClassification,

--- a/assets/ru/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_BLOOMZ_ZeroShot.py
+++ b/assets/ru/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_BLOOMZ_ZeroShot.py
@@ -18,7 +18,6 @@ def config():
         "dataset": SemEval23T3PropagandaDataset,
         "dataset_args": {"techniques_path": "techniques_subtask3.txt"},
         "task": MultilabelPropagandaTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": [

--- a/assets/ru/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_GPT4_FewShot.py
+++ b/assets/ru/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_GPT4_FewShot.py
@@ -18,7 +18,6 @@ def config():
         "dataset": SemEval23T3PropagandaDataset,
         "dataset_args": {"techniques_path": "techniques_subtask3.txt"},
         "task": MultilabelPropagandaTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ru/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_GPT4_ZeroShot.py
+++ b/assets/ru/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_GPT4_ZeroShot.py
@@ -18,7 +18,6 @@ def config():
         "dataset": SemEval23T3PropagandaDataset,
         "dataset_args": {"techniques_path": "techniques_subtask3.txt"},
         "task": MultilabelPropagandaTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": [

--- a/assets/ru/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_Random.py
+++ b/assets/ru/factuality_disinformation_harmful_content/propaganda/SemEval23T3Propaganda_Random.py
@@ -17,7 +17,6 @@ def config():
         "dataset": SemEval23T3PropagandaDataset,
         "dataset_args": {"techniques_path": "techniques_subtask3.txt"},
         "task": MultilabelPropagandaTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.MultiLabelClassification,

--- a/assets/tr/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_BLOOMZ_ZeroShot.py
+++ b/assets/tr/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_BLOOMZ_ZeroShot.py
@@ -14,9 +14,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22CheckworthinessDataset,
-        "dataset_args": {},
         "task": CheckworthinessTask,
-        "task_args": {},
         "model": PetalsModel,
         "model_args": {
             "class_labels": ["0", "1"],

--- a/assets/tr/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_GPT4_FewShot.py
+++ b/assets/tr/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_GPT4_FewShot.py
@@ -16,9 +16,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22CheckworthinessDataset,
-        "dataset_args": {},
         "task": CheckworthinessTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["0", "1"],

--- a/assets/tr/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_GPT4_ZeroShot.py
+++ b/assets/tr/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_GPT4_ZeroShot.py
@@ -16,9 +16,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22CheckworthinessDataset,
-        "dataset_args": {},
         "task": CheckworthinessTask,
-        "task_args": {},
         "model": OpenAIModel,
         "model_args": {
             "class_labels": ["0", "1"],

--- a/assets/tr/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_Random.py
+++ b/assets/tr/factuality_disinformation_harmful_content/checkworthyness/CT22Checkworthiness_Random.py
@@ -15,9 +15,7 @@ def metadata():
 def config():
     return {
         "dataset": CT22CheckworthinessDataset,
-        "dataset_args": {},
         "task": CheckworthinessTask,
-        "task_args": {},
         "model": RandomModel,
         "model_args": {
             "task_type": TaskType.Classification,

--- a/docs/tutorials/adding_asset.md
+++ b/docs/tutorials/adding_asset.md
@@ -11,14 +11,29 @@ def metadata():
 def config():
 	# This function returns a dictionary with the dataset, task and model provider
 	# the current run is targeting along with arguments for each of these, as well
-	# as a path to the dataset itself.
+	# as a path to the dataset itself. The structure is as follows:
+	# {
+	# 	"dataset": llmebench.dataset.*Dataset,
+	# 	"dataset_args": {}, # Optional, arguments passed to Dataset constructor
+	# 	"task": llmebench.task.*Task,
+	# 	"task_args": {}, # Optional, arguments passed to Task constructor
+	# 	"model": llmebench.model.*Model,
+	# 	"model_args": {}, # Optional, arguments passed to Model constructor
+	# 	"general_args": { # Optional to define splits, fewshot settings
+	# 		"test_split": "test-gold" # Optional, "test" will be picked from the dataset automatically if available
+	# 		"fewshot": {
+	# 			"train_split": "dev" # Optional, "train" will be picked from the dataset automatically if available
+	# 			"deduplicate": False # Optional, enable/disable train/test deduplication
+	# 		}
+	# 	}
+	# }
 
 def prompt(input_sample):
 	# This function receives an input_sample and pre-processes it into the
 	# expected input for the model being used. For instance, OpenAIModel expects
 	# its input to be a dictionary with two keys, ``system_message`` and a list
 	# of ``messages`` with the ``sender`` and ``text`` in each message.
-	# See the documentation linked with the available models for exact specifications
+	# See the documentation linked with the available model providers for exact specifications
 
 def post_process(response):
 	# This function takes the output from the model, and post-processes it to extract

--- a/tests/tasks/test_evaluation.py
+++ b/tests/tasks/test_evaluation.py
@@ -21,7 +21,9 @@ class TestAssetsTaskEvaluation(unittest.TestCase):
                 dataset_args["data_dir"] = ""
                 dataset = config["dataset"](**dataset_args)
                 data_sample = dataset.get_data_sample()
-                task = config["task"](dataset=dataset, **config["task_args"])
+
+                task_args = config.get("task_args", {})
+                task = config["task"](dataset=dataset, **task_args)
                 try:
                     task.evaluate([data_sample["label"]], [None])
                 except Exception as e:
@@ -42,7 +44,9 @@ class TestAssetsTaskEvaluation(unittest.TestCase):
                 dataset_args["data_dir"] = ""
                 dataset = config["dataset"](**dataset_args)
                 data_sample = dataset.get_data_sample()
-                task = config["task"](dataset=dataset, **config["task_args"])
+
+                task_args = config.get("task_args", {})
+                task = config["task"](dataset=dataset, **task_args)
                 evaluation_scores = task.evaluate(
                     [data_sample["label"]], [data_sample["label"]]
                 )


### PR DESCRIPTION
`dataset_args`, `model_args` and `task_args` are now optional in asset configs. This PR removes all empty arguments in existing assets and updates the tests+documentation to reflect this change.
