### PR TITLE
Add a new `assets` subcommand to manage assets.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,12 +13,25 @@ Before you begin, please ensure you have the following installed:
 ## How to Contribute
 1. **Fork the repository:** Fork the repository to your own GitHub account.
 2. **Clone the fork:** Clone your fork locally on your computer.
-3. **Set up environment:** Follow the instructions in the [README](https://github.com/qcri/LLMeBench#installation) to set up your development environment.
+  ```bash
+  git clone <url-of-LLMeBench-fork>
+  cd LLMeBench
+  ```
+3. **Set up environment:
+  Create and activate virtual environment:
+  ```bash
+  python -m venv .envs/llmebench
+  source .envs/llmebench/bin/activate
+  ```
+
+  Install the dependencies and benchmarking package:
+  ```bash
+  pip install -e '.[dev,fewshot]'
+  ```
 4. **Create a new branch:** Create a new branch for your contribution.
 5. **Make changes:** Implement your changes, additions, or fixes.
 6. **Test:** Run tests to ensure your changes do not break existing functionality.
 7. **Submit a pull request:** Push your changes to your fork on GitHub and then create a pull request for review.
-
 
 ## Adding New Dataset, Task, Models or Features
 If you are adding [new dataset, task, models or features](docs/tutorials), please ensure:

--- a/README.md
+++ b/README.md
@@ -31,35 +31,16 @@ Developing **LLMeBench** is an ongoing effort and it will be continuously expand
 - Open-source.
 
 ## Quick Start!
-1. [Install](https://github.com/qcri/LLMeBench/blob/main/README.md#installation) LLMeBench.
-2. Create a new folder "data", then [download ArSAS dataset](https://llmebench.qcri.org/data/ArSAS.zip) into "data" and unzip it.
-3. Evaluate!
+1. Install LLMeBench: `pip install llmebench`
+2. Download the current assets: `python -m llmebench assets download`. This will fetch assets and place them in the current working directory.
+3. Download one of the dataset, e.g. ArSAS. `python -m llmebench data download ArSAS`. This will download the data to the current working directory inside the `data` folder.
+4. Evaluate!
 
-   For example, to evaluate the performance of a [random baseline](llmebench/models/RandomGPT.py) for Sentiment analysis on [ArSAS dataset](https://github.com/qcri/LLMeBench/blob/main/llmebench/datasets/ArSAS.py), you need to create an ["asset"](assets/ar/sentiment_emotion_others/sentiment/ArSAS_random.py): a file that specifies the dataset, model and task to evaluate, then run the evaluation as follows:
+   For example, to evaluate the performance of a random baseline for Sentiment analysis on [ArSAS dataset](https://github.com/qcri/LLMeBench/blob/main/llmebench/datasets/ArSAS.py), you can run:
    ```bash
    python -m llmebench --filter 'sentiment/ArSAS_Random*' assets/ results/
    ```
-   where `ArSAS_Random` is the asset name referring to the `ArSAS` dataset name and the `Random` model, and `assets/ar/sentiment_emotion_others/sentiment/` is the directory where the benchmarking asset for the sentiment analysis task on Arabic ArSAS dataset can be found. Results will be saved in a directory called `results`.
-
-## Installation
-*pip package to be made available soon!*
-
-Clone this repository:
-```bash
-git clone https://github.com/qcri/LLMeBench.git
-cd LLMeBench
-```
-
-Create and activate virtual environment:
-```bash
-python -m venv .envs/llmebench
-source .envs/llmebench/bin/activate
-```
-
-Install the dependencies and benchmarking package:
-```bash
-pip install -e '.[dev,fewshot]'
-```
+   which uses the [ArSAS_random "asset"](assets/ar/sentiment_emotion_others/sentiment/ArSAS_random.py): a file that specifies the dataset, model and task to evaluate. Here, `ArSAS_Random` is the asset name referring to the `ArSAS` dataset name and the `Random` model, and `assets/ar/sentiment_emotion_others/sentiment/` is the directory where the benchmarking asset for the sentiment analysis task on Arabic ArSAS dataset can be found. Results will be saved in a directory called `results`.
 
 ## Get the Benchmark Data
 In addition to supporting the user to implement their own LLM evaluation and benchmarking experiments, the framework comes equipped with benchmarking assets over a large variety of datasets and NLP tasks. To benchmark models on the same datasets, the framework *automatically* downloads the datasets when possible. Manually downloading them (for example to explore the data before running any assets) can be done as follows:

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ pip install -e '.[dev,fewshot]'
 In addition to supporting the user to implement their own LLM evaluation and benchmarking experiments, the framework comes equipped with benchmarking assets over a large variety of datasets and NLP tasks. To benchmark models on the same datasets, the framework *automatically* downloads the datasets when possible. Manually downloading them (for example to explore the data before running any assets) can be done as follows:
 
 ```bash
-python -m llmebench download <DatasetName>
+python -m llmebench data download <DatasetName>
 ```
 
 **_Voilà! all ready to start evaluation..._**

--- a/llmebench/asset_utils.py
+++ b/llmebench/asset_utils.py
@@ -1,0 +1,56 @@
+import logging
+
+from pathlib import Path
+
+from git import Repo
+
+DEFAULT_REMOTE_NAME = "origin"
+DEFAULT_REMOTE_REPO = "https://github.com/qcri/LLMeBench.git"
+
+
+def download_all(work_dir):
+    if isinstance(work_dir, str):
+        work_dir = Path(work_dir)
+
+    repo = Repo.init(work_dir)
+
+    # Create a new remote if there isn't one already created
+    if len(repo.remotes) == 0:
+        logging.info("Setting up git repo to track assets")
+        origin = repo.create_remote(DEFAULT_REMOTE_NAME, DEFAULT_REMOTE_REPO)
+        with open(work_dir / ".git/info/sparse-checkout", "w") as fp:
+            fp.write("assets\n")
+    else:
+        # Already in a git repository, checking if this is created by the auto-downloader
+        if not (
+            repo.remotes[0].name == DEFAULT_REMOTE_NAME
+            and repo.remotes[0].url == DEFAULT_REMOTE_REPO
+        ):
+            logging.error(
+                "assets must be downloaded in a clean work_dir that is not already a git repo"
+            )
+            return False
+        else:
+            sparse_checkout_file = work_dir / ".git/info/sparse-checkout"
+
+            if not sparse_checkout_file.exists():
+                logging.error(
+                    "This seems to be a git repository cloned from LLMeBench directly. Please use `git pull` to update your assets."
+                )
+                return False
+            else:
+                with open(sparse_checkout_file) as fp:
+                    lines = fp.readlines()
+
+                    if len(lines) != 1 or lines[0] != "assets\n":
+                        logging.error(
+                            "This seems to be a git repository cloned from LLMeBench directly. Please use `git pull` to update your assets."
+                        )
+                        return False
+
+    logging.info("Downloading/updating assets")
+    git = repo.git()
+    git.config("core.sparseCheckout", True)
+    git.pull("origin", "main")
+
+    return True

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ install_requires =
     evaluate==0.4.2
     rouge-score==0.1.2
     absl-py==2.1.0
+    GitPython==3.1.43
 python_requires = >=3.8
 
 [options.extras_require]


### PR DESCRIPTION
This commit adds a new `assets` subcommand to manage various asset related functions. Currently one function is implemented, which is downloading/updating latest assets. This is done by running

```bash
python -m llmebench assets download
```

which downloads assets from our git repo in the current working directory. This command also accepts an optional `--work_dir` argument, which controls where the assets are downloaded (they will appear in `<work_dir>/assets`, along with a hidden `<work_dir>/.git` that tracks the assets).

For consistency sake, I've also moved the older "download" command to be under a dedicated "data" subcommand.

So:

```bash
python -m llmebench download ArSAS
```

now becomes

```bash
python -m llmebench data download ArSAS
```